### PR TITLE
Move paygov models

### DIFF
--- a/peacecorps/paygov/migrations/0002_auto_20141020_2012.py
+++ b/peacecorps/paygov/migrations/0002_auto_20141020_2012.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import paygov.models
+import peacecorps
 
 
 class Migration(migrations.Migration):
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='donorinfo',
             name='expires_at',
-            field=models.DateTimeField(default=paygov.models.default_expire_time),
+            field=models.DateTimeField(default=peacecorps.models.default_expire_time),
             preserve_default=True,
         ),
         migrations.AlterField(

--- a/peacecorps/paygov/migrations/0003_auto_20141021_1605.py
+++ b/peacecorps/paygov/migrations/0003_auto_20141021_1605.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('paygov', '0002_auto_20141020_2012'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='donorinfo',
+            name='fund',
+        ),
+        migrations.DeleteModel(
+            name='DonorInfo',
+        ),
+    ]

--- a/peacecorps/paygov/models.py
+++ b/peacecorps/paygov/models.py
@@ -1,18 +1,1 @@
-from datetime import timedelta
-
-from django.conf import settings
-from django.db import models
-from django.utils import timezone
-
-
-def default_expire_time():
-    return timezone.now() + timedelta(minutes=settings.DONOR_EXPIRE_AFTER)
-
-
-class DonorInfo(models.Model):
-    """Represents a blob of donor information which will be requested by
-    pay.gov. We need to limit accessibility as it contains PII"""
-    agency_tracking_id = models.CharField(max_length=21, primary_key=True)
-    fund = models.ForeignKey('peacecorps.Fund', related_name='donorinfos')
-    xml = models.TextField()    # @todo: encrypt
-    expires_at = models.DateTimeField(default=default_expire_time)
+# This file should contain no models that are needed by other apps

--- a/peacecorps/paygov/tests/test_views.py
+++ b/peacecorps/paygov/tests/test_views.py
@@ -1,8 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from paygov.models import DonorInfo
-from peacecorps.models import Fund
+from peacecorps.models import DonorInfo, Fund
 
 
 class DataTests(TestCase):

--- a/peacecorps/paygov/views.py
+++ b/peacecorps/paygov/views.py
@@ -5,7 +5,7 @@ from django.http import HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 
-from paygov.models import DonorInfo
+from peacecorps.models import DonorInfo
 
 
 @csrf_exempt

--- a/peacecorps/peacecorps/migrations/0007_donorinfo.py
+++ b/peacecorps/peacecorps/migrations/0007_donorinfo.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import peacecorps.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0006_auto_20141020_1344'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DonorInfo',
+            fields=[
+                ('agency_tracking_id', models.CharField(serialize=False, primary_key=True, max_length=21)),
+                ('xml', models.TextField()),
+                ('expires_at', models.DateTimeField(default=peacecorps.models.default_expire_time)),
+                ('fund', models.ForeignKey(to='peacecorps.Fund', related_name='donorinfos')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -4,8 +4,7 @@ from uuid import uuid4
 
 from django.conf import settings
 
-from paygov.models import DonorInfo
-from peacecorps.models import humanize_amount
+from peacecorps.models import DonorInfo, humanize_amount
 
 
 def add_subelements(parent, data, elements):

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -25,7 +25,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'peacecorps',
-    'paygov',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/peacecorps/peacecorps/settings/test.py
+++ b/peacecorps/peacecorps/settings/test.py
@@ -10,3 +10,5 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+
+INSTALLED_APPS += ('paygov',)

--- a/peacecorps/peacecorps/tests/test_xmlgen.py
+++ b/peacecorps/peacecorps/tests/test_xmlgen.py
@@ -1,7 +1,8 @@
+from xml.etree.ElementTree import tostring
+
 from django.test import TestCase
 
-from paygov import payxml
-from xml.etree.ElementTree import tostring
+from peacecorps import payxml
 
 
 def donor_custom_fields():

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -5,11 +5,11 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 
-from paygov.payxml import convert_to_paygov
 from peacecorps.forms import DonationAmountForm, DonationPaymentForm
 from peacecorps.models import CountryFund, FeaturedIssue
 from peacecorps.models import FeaturedProjectFrontPage, Fund, humanize_amount
 from peacecorps.models import Issue, Project
+from peacecorps.payxml import convert_to_paygov
 
 
 def donation_payment(request):


### PR DESCRIPTION
Removes the models (and associated functions) from paygov app and places them in the peacecorps app.

Deactivates paygov from the base settings file, and adds it to the tests file. We'll need to add it to individual local_settings files when those urls need to be active.
