### PR TITLE
Second Pay.gov callback

### DIFF
--- a/peacecorps/paygov/tests/test_views.py
+++ b/peacecorps/paygov/tests/test_views.py
@@ -97,3 +97,4 @@ class ResultsTests(TestCase):
         self.assertEqual(1, len(fund.donations.all()))
         donation = fund.donations.all()[0]
         self.assertEqual(donation.amount, 12500)
+        self.assertEqual(0, len(fund.donorinfos.all()))

--- a/peacecorps/paygov/tests/test_views.py
+++ b/peacecorps/paygov/tests/test_views.py
@@ -33,3 +33,67 @@ class DataTests(TestCase):
                                   data={'agency_tracking_id': 'TRACK'})
         self.assertEqual(result.content, b'XML')
         self.assertEqual(result['Content-Type'], 'text/xml')
+
+
+class ResultsTests(TestCase):
+    """Tests the results() view"""
+    def setUp(self):
+        self.fund = Fund.objects.create(fundcode='FUNDFUND')
+        self.donorinfo = DonorInfo.objects.create(agency_tracking_id='TRACK',
+                                                  fund=self.fund, xml='XML')
+
+    def tearDown(self):
+        self.fund.delete()  # cascades
+
+    def test_requires_post(self):
+        result = self.client.get(reverse('paygov:results'),
+                                 data={'agency_tracking_id': 'TRACK'})
+        self.assertEqual(result.status_code, 405)
+
+    def test_param(self):
+        """The view requires several fields and specific formats for those
+        fields."""
+        successful = {'agency_tracking_id': 'TRACK',
+                      'payment_status': 'Completed',
+                      'payment_amount': '125.00'}
+        data = dict(successful)
+        del data['agency_tracking_id']
+        result = self.client.post(reverse('paygov:results'), data=data)
+        self.assertContains(result, 'agency_tracking_id')
+
+        data = dict(successful, agency_tracking_id='BAD')
+        result = self.client.post(reverse('paygov:results'), data=data)
+        self.assertContains(result, 'agency_tracking_id')
+
+        data = dict(successful, payment_status='Canceled')
+        result = self.client.post(reverse('paygov:results'), data=data)
+        self.assertContains(result, 'Unknown error')
+
+        data['error_message'] = 'ABCDEFG'
+        result = self.client.post(reverse('paygov:results'), data=data)
+        self.assertContains(result, 'ABCDEFG')
+
+        data = dict(successful)
+        del data['payment_amount']
+        result = self.client.post(reverse('paygov:results'), data=data)
+        self.assertContains(result, 'payment_amount')
+
+        data = dict(successful, payment_amount='1.2.3')
+        result = self.client.post(reverse('paygov:results'), data=data)
+        self.assertContains(result, 'payment_amount')
+
+    def test_success(self):
+        """Verify mimetype and that donation is made when passed the right
+        values"""
+        successful = {'agency_tracking_id': 'TRACK',
+                      'payment_status': 'Completed',
+                      'payment_amount': '125.00'}
+        result = self.client.post(reverse('paygov:results'), data=successful)
+        self.assertEqual(result.content, b'response_message=OK')
+        self.assertEqual(result['Content-Type'], 'text/plain')
+
+        # avoiding the cache
+        fund = Fund.objects.get(pk=self.fund.pk)
+        self.assertEqual(1, len(fund.donations.all()))
+        donation = fund.donations.all()[0]
+        self.assertEqual(donation.amount, 12500)

--- a/peacecorps/paygov/urls.py
+++ b/peacecorps/paygov/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import patterns, url
 
-from paygov.views import data
+from paygov.views import data, results
 
 
 urlpatterns = patterns(
     '',
-    url(r'^data/?$', data, name='data')
-    # url(r'^results/?$', results)
+    url(r'^data/?$', data, name='data'),
+    url(r'^results/?$', results, name='results')
     # url(r'^settlement/?$', settlement)
 )

--- a/peacecorps/paygov/views.py
+++ b/peacecorps/paygov/views.py
@@ -1,11 +1,12 @@
 import logging
+import re
 
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.http import HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 
-from peacecorps.models import DonorInfo
+from peacecorps.models import Donation, DonorInfo
 
 
 @csrf_exempt
@@ -20,3 +21,36 @@ def data(request):
         info = get_object_or_404(
             DonorInfo, pk=request.POST.get('agency_tracking_id'))
         return HttpResponse(info.xml, content_type='text/xml')
+
+
+@csrf_exempt
+def results(request):
+    logger = logging.getLogger('paygov.results')
+    logger.debug(request)
+    message = 'OK'
+    if request.method != 'POST':
+        return HttpResponseNotAllowed(['POST'])
+    if not request.POST.get('agency_tracking_id'):
+        message = 'Missing agency_tracking_id'
+    elif not request.POST.get('payment_status'):
+        message = 'Missing payment_status'
+    elif request.POST.get('payment_status') != 'Completed':
+        message = request.POST.get('error_message', 'Unknown error')
+    elif not request.POST.get('payment_amount'):
+        message = 'Missing payment_amount'
+    elif not re.match(r'^\d+\.\d{2}$', request.POST.get('payment_amount')):
+        message = 'Invalid payment_amount'
+    else:
+        info = DonorInfo.objects.filter(
+            pk=request.POST.get('agency_tracking_id')).first()
+        if not info:
+            message = 'Invalid agency_tracking_id'
+        else:
+            donation = Donation(
+                amount=float(request.POST.get('payment_amount'))*100)
+            donation.fund_id = info.fund_id
+            donation.save()
+            info.delete()
+            message = 'OK'
+    return HttpResponse('response_message=' + message,
+                        content_type='text/plain')

--- a/peacecorps/peacecorps/migrations/0008_donation.py
+++ b/peacecorps/peacecorps/migrations/0008_donation.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0007_donorinfo'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Donation',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, serialize=False, verbose_name='ID')),
+                ('amount', models.PositiveIntegerField()),
+                ('time', models.DateTimeField(auto_now=True)),
+                ('fund', models.ForeignKey(related_name='donations', to='peacecorps.Fund')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -230,3 +230,10 @@ class DonorInfo(models.Model):
     fund = models.ForeignKey(Fund, related_name='donorinfos')
     xml = models.TextField()    # @todo: encrypt
     expires_at = models.DateTimeField(default=default_expire_time)
+
+
+class Donation(models.Model):
+    """Log donation amounts as received from pay.gov"""
+    fund = models.ForeignKey(Fund, related_name='donations')
+    amount = models.PositiveIntegerField()
+    time = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
- Adds a new model to track individual donations
- Responds to pay.gov with error information during any of a half-dozen error conditions
- Otherwise, saves the donation, deletes the donor info, and responds with success
