### PR TITLE
Add test settings into dev

### DIFF
--- a/peacecorps/peacecorps/settings/dev.py
+++ b/peacecorps/peacecorps/settings/dev.py
@@ -1,9 +1,21 @@
 from .base import *
 
+from django.utils.crypto import get_random_string
+
 DEBUG = True
 TEMPLATE_DEBUG = True
 
 INTERNAL_IPS = ('127.0.0.1',)
+SECRET_KEY = get_random_string(50)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}
+
+INSTALLED_APPS += ('paygov',)
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Merges settings in test to dev so running tests does not require
separate setting file. Adds paygov app into main dev settings.

Other changes:
- Added **init**.py file in settings folder, to ensure files can be
  accessed as modules.

Testing done:
Did not add addtional tests because not testing configuration. Ran
existing tests successfully:

> python manage.py test
> Ran 37 tests in 15.353s
