### PR TITLE
Few field fixes on donor info page

### DIFF
--- a/peacecorps/peacecorps/forms.py
+++ b/peacecorps/peacecorps/forms.py
@@ -2,8 +2,7 @@ from decimal import Decimal
 
 from django import forms
 from django.core.exceptions import ValidationError
-from localflavor.us.forms import USStateField
-from localflavor.us.forms import USStateSelect
+from localflavor.us.us_states import STATE_CHOICES
 
 from .countries import COUNTRY_OPTIONS
 
@@ -40,11 +39,12 @@ class DonationPaymentForm(forms.Form):
         label='Contact Person', max_length=100, required=False)
 
     email = forms.EmailField(required=False)
+    # Be sure that country is processed before billing_state/zip
+    country = forms.ChoiceField(choices=COUNTRY_CHOICES, initial='USA')
     billing_address = forms.CharField(label="Street Address", max_length=80)
     billing_city = forms.CharField(label="City", max_length=40)
-    billing_state = USStateField(
-        label="State", widget=USStateSelect, required=False)
-    country = forms.ChoiceField(choices=COUNTRY_CHOICES, initial='USA')
+    billing_state = forms.ChoiceField(
+        label="State", choices=((('', ''),) + STATE_CHOICES), required=False)
     billing_zip = forms.CharField(required=False)
     phone_number = forms.CharField(required=False, max_length=15)
     payment_type = forms.ChoiceField(

--- a/peacecorps/peacecorps/templates/donations/donation_payment.jinja
+++ b/peacecorps/peacecorps/templates/donations/donation_payment.jinja
@@ -66,7 +66,7 @@
 
         <div>
             {{form.phone_number.errors}}
-            <label for="id_phone_number" class="required">Phone</label>
+            <label for="id_phone_number">Phone</label>
             <div class="value">{{form.phone_number}}</div>
         </div>
 

--- a/peacecorps/peacecorps/tests/test_forms.py
+++ b/peacecorps/peacecorps/tests/test_forms.py
@@ -83,10 +83,15 @@ class DonationPaymentTests(TestCase):
 
     def test_zip_state_requirements(self):
         """Zip code and state are only required when the country is the US"""
-        form_data = self.form_data(clear=['billing_state', 'billing_zip'])
+        form_data = self.form_data(clear=['billing_state'])
         form = DonationPaymentForm(data=form_data)
         self.assertFalse(form.is_valid())
 
+        form_data = self.form_data(clear=['billing_zip'])
+        form = DonationPaymentForm(data=form_data)
+        self.assertFalse(form.is_valid())
+
+        form_data = self.form_data(clear=['billing_state', 'billing_zip'])
         form_data['country'] = 'CAN'
         form = DonationPaymentForm(data=form_data)
         self.assertTrue(form.is_valid())

--- a/peacecorps/peacecorps/tests/test_forms.py
+++ b/peacecorps/peacecorps/tests/test_forms.py
@@ -87,6 +87,10 @@ class DonationPaymentTests(TestCase):
         form = DonationPaymentForm(data=form_data)
         self.assertFalse(form.is_valid())
 
+        form_data = self.form_data(billing_state='')
+        form = DonationPaymentForm(data=form_data)
+        self.assertFalse(form.is_valid())
+
         form_data = self.form_data(clear=['billing_zip'])
         form = DonationPaymentForm(data=form_data)
         self.assertFalse(form.is_valid())


### PR DESCRIPTION
- Remove the "required" star on phone - this isn't actually required (and shouldn't be)
- Test missing state and zip (when USA is selected) separately -- they were tested together
- Fix related ordering issue where country was not processed in time to test for an empty state selection
- Add an empty option for state selection - so that non-US selections don't need to have selected a state
