### PR TITLE
Settings rejigger + S3 for media storage

### DIFF
--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -18,25 +18,11 @@ DATABASES = {}
 # Application definition
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
+    'django.contrib.contenttypes',  # may be okay to remove
     'django.contrib.staticfiles',
     'peacecorps',
-    'tinymce',
 )
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
 
 ROOT_URLCONF = 'peacecorps.urls'
 WSGI_APPLICATION = 'peacecorps.wsgi.application'
@@ -59,34 +45,32 @@ USE_L10N = True
 USE_TZ = True
 
 
+# TinyMCE configurations
+TINYMCE_DEFAULT_CONFIG = {
+    'theme': "advanced",
+    'theme_advanced_toolbar_location': "top",
+    'theme_advanced_buttons1': "bold,italic,underline,separator,bullist,separator,outdent,indent,separator,undo,redo",
+    'theme_advanced_buttons2': "",
+    'theme_advanced_buttons3': "",
+    'width': '70%',
+    'height': 300,
+}
+STATIC_ROOT = '/var/www/static/'
+
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 STATIC_URL = '/static/'
 
 # APP_SPECIFIC_VALUES
 
-# The agency id assigned by pay.gov
+# Not secret information -- it's in donation form
 PAY_GOV_AGENCY_ID = '1247'
-
-# The name of the agency application in pay.gov
-PAY_GOV_APP_NAME = 'DONORPAGES'
+PAY_GOV_APP_NAME = 'DONORPAGES2'
+PAY_GOV_FORM_ID = 'DONORPAGES2'
 
 # The URL for the pay.gov payment service.
-PAY_GOV_OCI_URL = 'mockpay'
-
-# TinyMCE configurations
-TINYMCE_DEFAULT_CONFIG = {
-    'theme': "advanced",
-    'theme_advanced_toolbar_location' : "top",
-    'theme_advanced_buttons1': "bold,italic,underline,separator,bullist,separator,outdent,indent,separator,undo,redo",
-    'theme_advanced_buttons2': "",
-    'theme_advanced_buttons3': "",
-    'width' : '70%',
-    'height' : 300,
-    }
-
-# This id is also provided by pay.gov
-PAY_GOV_FORM_ID = 'TODO'
+PAY_GOV_OCI_URL = 'https://example.com/'
 
 # DonorInfo objects expire after a set period of time
 DONOR_EXPIRE_AFTER = 30      # minutes

--- a/peacecorps/peacecorps/settings/dev.py
+++ b/peacecorps/peacecorps/settings/dev.py
@@ -15,7 +15,24 @@ DATABASES = {
     }
 }
 
-INSTALLED_APPS += ('paygov',)
+INSTALLED_APPS += (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'tinymce',
+    'paygov'
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
 
 LOGGING = {
     'version': 1,
@@ -38,7 +55,6 @@ LOGGING = {
 
 MEDIA_ROOT = './media/'
 MEDIA_URL = '/media/'
-STATIC_ROOT = '/static/'
 
 try:
     from .local_settings import *

--- a/peacecorps/peacecorps/settings/production-admin.py
+++ b/peacecorps/peacecorps/settings/production-admin.py
@@ -1,0 +1,31 @@
+from .production import *
+
+INSTALLED_APPS += (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'tinymce',
+)
+# Set these only on the machines which have admin access
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+AWS_STORAGE_BUCKET_NAME = 'peace-corps'
+AWS_QUERYSTRING_AUTH = False
+AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
+AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+
+try:
+    from .local_settings import *
+except ImportError:
+    pass

--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -1,4 +1,39 @@
+import os
+
 from .base import *
+
+
+INSTALLED_APPS += ('storages',)
+
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '')
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']  # proxied
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "NAME": os.environ.get('PG_NAME', ''),
+        "USER": os.environ.get('PG_USER', ''),
+        "PASSWORD": os.environ.get('PG_PASS', ''),
+        "HOST": os.environ.get('PG_HOST', ''),
+    },
+}
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+# Note that MEDIA_ROOT is not needed since we're using S3
+MEDIA_URL = '//peace-corps.s3.amazonaws.com/'
+
+GNUPG_HOME = os.environ.get('GNUPG_HOME', '')
+GPG_RECIPIENTS = {
+    'peacecorps.fields.GPGField.xml': os.environ.get('GPG_ENCRYPT_ID', '')
+}
+
+# Add this to local settings only on the machines which pay.gov contact
+# INSTALLED_APPS += ('paygov',)
+
 
 try:
     from .local_settings import *

--- a/peacecorps/peacecorps/settings/test.py
+++ b/peacecorps/peacecorps/settings/test.py
@@ -11,6 +11,21 @@ DATABASES = {
     }
 }
 
-STATIC_ROOT = '/static/'
+INSTALLED_APPS += (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'tinymce',
+    'paygov'
+)
 
-INSTALLED_APPS += ('paygov',)
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)

--- a/peacecorps/peacecorps/urls.py
+++ b/peacecorps/peacecorps/urls.py
@@ -2,7 +2,6 @@ from django.apps import apps
 from django.conf import settings
 from django.conf.urls import include, patterns, url
 from django.conf.urls.static import static
-from django.contrib import admin
 
 from peacecorps.views import donation_failure, donation_payment
 from peacecorps.views import donation_success
@@ -17,8 +16,6 @@ from peacecorps.views import donate_general
 
 urlpatterns = patterns(
     '',
-    url(r'^tinymce/', include('tinymce.urls')),
-    url(r'^admin/', include(admin.site.urls)),
     url(r'^donate/?$', donate_landing, name='donate landing'),
     url(r'^donate/issue/(?P<slug>[a-zA-Z0-9_-]*)/?$',
         donate_issue, name='donate issue'),
@@ -48,3 +45,12 @@ if settings.DEBUG:
 if apps.is_installed('paygov'):
     urlpatterns += patterns(
         '', url(r'^callback/', include('paygov.urls', namespace='paygov')))
+
+if apps.is_installed('django.contrib.admin'):
+    from django.contrib import admin
+    urlpatterns += patterns(
+        '', url(r'^admin/', include(admin.site.urls)))
+
+if apps.is_installed('tinymce'):
+    urlpatterns += patterns(
+        '', url(r'^tinymce/', include('tinymce.urls')))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ django-localflavor
 django-tinymce
 pyyaml
 python-gnupg
+pytz
+boto
+# @see http://code.larlet.fr/django-storages/issue/155/python-3-support
+-e git+https://github.com/coagulant/django-storages-py3.git#egg=django-storages


### PR DESCRIPTION
There are now four settings files: base, dev, production, and production-admin.
- `base` is shared by the other three; it includes only apps needed by all servers
- `production` now includes environmental configurations. This settings file will be used on the normal web servers
- `production-admin` includes production, but also includes apps for the admin screens (including sessions, messages, users, etc. etc.). It's also now configured to upload images to S3. This app would be used by editors, and its access should be limited.
- `dev` includes all apps, but serves everything from the local disk

Technically, there's also `test`, which may just be replaced with `dev` at some point.

The URLs file now pays attention to which apps are installed, no longer including admin nor tinymce in the production. This does not account for the `paygov` app, which may live on the admin servers or completely separately.

@annalee @khandelwal @seanherron - Would you mind reviewing this setup?
