### PR TITLE
Remove need for local_settings in production

### DIFF
--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -73,7 +73,7 @@ PAY_GOV_APP_NAME = 'DONORPAGES2'
 PAY_GOV_FORM_ID = 'DONORPAGES2'
 
 # The URL for the pay.gov payment service.
-PAY_GOV_OCI_URL = 'https://example.com/'
+PAY_GOV_OCI_URL = os.environ.get('PAY_GOV_OCI_URL', 'https://example.com/')
 
 # DonorInfo objects expire after a set period of time
 DONOR_EXPIRE_AFTER = 30      # minutes

--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -31,8 +31,8 @@ GPG_RECIPIENTS = {
     'peacecorps.fields.GPGField.xml': os.environ.get('GPG_ENCRYPT_ID', '')
 }
 
-# Add this to local settings only on the machines which pay.gov contact
-# INSTALLED_APPS += ('paygov',)
+if os.environ.get('USE_PAYGOV', ''):
+    INSTALLED_APPS += ('paygov',)
 
 
 try:


### PR DESCRIPTION
This allows the `PAY_GOV_OCI_URL` and whether or not the paygov app is included to be configured via environmental variables, rather in `local_settings.py`.
