### PR TITLE
Tell pay.gov to use success/fail urls

### DIFF
--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -6,10 +6,17 @@ from peacecorps.views import humanize_amount
 
 
 class DonationsTests(TestCase):
+    fixtures = ['countries.yaml']
+
     def setUp(self):
-        self.account = Account.objects.create(code='FUNDFUND')
+        self.account = Account.objects.create(
+            code='FUNDFUND', category=Account.PROJECT)
+        self.project = Project.objects.create(
+            slug='sluggy', country=Country.objects.get(name='Egypt'),
+            account=self.account)
 
     def tearDown(self):
+        self.project.delete()
         self.account.delete()
 
     def test_contribution_parameters(self):


### PR DESCRIPTION
Augment the pay.gov interaction to request that project/campaign specific success/failure urls be used. This performs that task by moving backwards from an Account to its associated project/campaign. That reverse lookup might be useful for other tasks, so we may want to pull it out.
