### PR TITLE
Modified production settings to allow from any hostname

### DIFF
--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -6,9 +6,7 @@ from .base import *
 INSTALLED_APPS += ('storages',)
 
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '')
-ALLOWED_HOSTS = ['localhost', '127.0.0.1']  # proxied
-if os.environ.get('DJANGO_HOST'):
-    ALLOWED_HOSTS.append(os.environ.get('DJANGO_HOST'))
+ALLOWED_HOSTS = ['*']  # proxied
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
This PR attempts modifying `ALLOWED_HOSTS` to allow from any domain name. Since in production we will be operating inside a private subnet with no access that we don't allow through the LB, this should still be a safe default.
