### PR TITLE
Specify storages branch; add test for travis

### DIFF
--- a/peacecorps/peacecorps/settings/test.py
+++ b/peacecorps/peacecorps/settings/test.py
@@ -29,3 +29,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+# Verify that the django-storages lib is not broken
+import storages.backends.s3boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ python-gnupg
 pytz
 boto
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
--e git+https://github.com/coagulant/django-storages-py3.git#egg=django-storages
+-e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages


### PR DESCRIPTION
The py3 fork of django-storages changed its branch name (or I'm crazy) which broke py3 compatibility. This fixes that and adds an import so that travis will explode if something similar happens again.
