### PR TITLE
Better pathnames for GPG fields

### DIFF
--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -81,5 +81,5 @@ DONOR_EXPIRE_AFTER = 30      # minutes
 # GPG info for encrypted fields
 GNUPG_HOME = ''     # Directory containing keys. If empty, GPG will not be used
 GPG_RECIPIENTS = {
-    'peacecorps.fields.GPGField.xml': '00000000'
+    'peacecorps.DonorInfo.xml': '00000000'
 }

--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -29,7 +29,7 @@ MEDIA_URL = '//peace-corps.s3.amazonaws.com/'
 
 GNUPG_HOME = os.environ.get('GNUPG_HOME', '')
 GPG_RECIPIENTS = {
-    'peacecorps.fields.GPGField.xml': os.environ.get('GPG_ENCRYPT_ID', '')
+    'peacecorps.DonorInfo.xml': os.environ.get('GPG_ENCRYPT_ID', '')
 }
 
 if os.environ.get('USE_PAYGOV', ''):

--- a/peacecorps/peacecorps/tests/test_gpg.py
+++ b/peacecorps/peacecorps/tests/test_gpg.py
@@ -39,7 +39,7 @@ class GPGTests(TestCase):
         with self.settings(GNUPG_HOME=os.path.join('peacecorps', 'tests',
                                                    'gpg'),
                            GPG_RECIPIENTS={
-                               'peacecorps.fields.GPGField.xml': 'C68F6B22'}):
+                               'peacecorps.DonorInfo.xml': 'C68F6B22'}):
             di = DonorInfo(agency_tracking_id='TRACK', account=self.account,
                            xml='Plain Text')
             di.save()


### PR DESCRIPTION
This fixes an annoyance regarding GPGField configuration. It replaces referencing by field class name (which makes no sense) with `app_name.model_name.field`
