### PR TITLE
Fixtures for country, memorial, issues, and other campaigns

### DIFF
--- a/peacecorps/peacecorps/fixtures/countryfunds.yaml
+++ b/peacecorps/peacecorps/fixtures/countryfunds.yaml
@@ -1,0 +1,1243 @@
+- fields: {category: coun, code: 304-CFD, community_contribution: null, current: 0,
+    goal: null, name: Albania}
+  model: peacecorps.account
+  pk: 3
+- fields: {category: coun, code: 305-CFD, community_contribution: null, current: 0,
+    goal: null, name: Armenia}
+  model: peacecorps.account
+  pk: 4
+- fields: {category: coun, code: 314-CFD, community_contribution: null, current: 0,
+    goal: null, name: Azerbaijan}
+  model: peacecorps.account
+  pk: 5
+- fields: {category: coun, code: 535-CFD, community_contribution: null, current: 0,
+    goal: null, name: Belize}
+  model: peacecorps.account
+  pk: 6
+- fields: {category: coun, code: 680-CFD, community_contribution: null, current: 0,
+    goal: null, name: Benin}
+  model: peacecorps.account
+  pk: 7
+- fields: {category: coun, code: 637-CFD, community_contribution: null, current: 0,
+    goal: null, name: Botswana}
+  model: peacecorps.account
+  pk: 8
+- fields: {category: coun, code: 686-CFD, community_contribution: null, current: 0,
+    goal: null, name: Burkina Faso}
+  model: peacecorps.account
+  pk: 9
+- fields: {category: coun, code: 303-CFD, community_contribution: null, current: 0,
+    goal: null, name: Cambodia}
+  model: peacecorps.account
+  pk: 10
+- fields: {category: coun, code: 694-CFD, community_contribution: null, current: 0,
+    goal: null, name: Cameroon}
+  model: peacecorps.account
+  pk: 11
+- fields: {category: coun, code: 366-CFD, community_contribution: null, current: 0,
+    goal: null, name: China}
+  model: peacecorps.account
+  pk: 12
+- fields: {category: coun, code: 514-CFD, community_contribution: null, current: 0,
+    goal: null, name: Colombia}
+  model: peacecorps.account
+  pk: 13
+- fields: {category: coun, code: 515-CFD, community_contribution: null, current: 0,
+    goal: null, name: Costa Rica}
+  model: peacecorps.account
+  pk: 14
+- fields: {category: coun, code: 517-CFD, community_contribution: null, current: 0,
+    goal: null, name: Dominican Republic}
+  model: peacecorps.account
+  pk: 15
+- fields: {category: coun, code: 538-CFD, community_contribution: null, current: 0,
+    goal: null, name: East Caribbean}
+  model: peacecorps.account
+  pk: 301
+- fields: {category: coun, code: 518-CFD, community_contribution: null, current: 0,
+    goal: null, name: Ecuador}
+  model: peacecorps.account
+  pk: 16
+- fields: {category: coun, code: 519-CFD, community_contribution: null, current: 0,
+    goal: null, name: El Salvador}
+  model: peacecorps.account
+  pk: 17
+- fields: {category: coun, code: 663-CFD, community_contribution: null, current: 0,
+    goal: null, name: Ethiopia}
+  model: peacecorps.account
+  pk: 18
+- fields: {category: coun, code: 411-CFD, community_contribution: null, current: 0,
+    goal: null, name: Fiji}
+  model: peacecorps.account
+  pk: 19
+- fields: {category: coun, code: 635-CFD, community_contribution: null, current: 0,
+    goal: null, name: Gambia}
+  model: peacecorps.account
+  pk: 304
+- fields: {category: coun, code: 242-CFD, community_contribution: null, current: 0,
+    goal: null, name: Georgia}
+  model: peacecorps.account
+  pk: 20
+- fields: {category: coun, code: 641-CFD, community_contribution: null, current: 0,
+    goal: null, name: Ghana}
+  model: peacecorps.account
+  pk: 21
+- fields: {category: coun, code: 520-CFD, community_contribution: null, current: 0,
+    goal: null, name: Guatemala}
+  model: peacecorps.account
+  pk: 22
+- fields: {category: coun, code: 675-CFD, community_contribution: null, current: 0,
+    goal: null, name: Guinea}
+  model: peacecorps.account
+  pk: 23
+- fields: {category: coun, code: 504-CFD, community_contribution: null, current: 0,
+    goal: null, name: Guyana}
+  model: peacecorps.account
+  pk: 24
+- fields: {category: coun, code: 497-CFD, community_contribution: null, current: 0,
+    goal: null, name: Indonesia}
+  model: peacecorps.account
+  pk: 25
+- fields: {category: coun, code: 532-CFD, community_contribution: null, current: 0,
+    goal: null, name: Jamaica}
+  model: peacecorps.account
+  pk: 26
+- fields: {category: coun, code: 440-CFD, community_contribution: null, current: 0,
+    goal: null, name: Jordan}
+  model: peacecorps.account
+  pk: 27
+- fields: {category: coun, code: 615-CFD, community_contribution: null, current: 0,
+    goal: null, name: Kenya}
+  model: peacecorps.account
+  pk: 28
+- fields: {category: coun, code: 216-CFD, community_contribution: null, current: 0,
+    goal: null, name: Kosovo}
+  model: peacecorps.account
+  pk: 302
+- fields: {category: coun, code: 307-CFD, community_contribution: null, current: 0,
+    goal: null, name: Kyrgyz Republic}
+  model: peacecorps.account
+  pk: 303
+- fields: {category: coun, code: 632-CFD, community_contribution: null, current: 0,
+    goal: null, name: Lesotho}
+  model: peacecorps.account
+  pk: 29
+- fields: {category: coun, code: 669-CFD, community_contribution: null, current: 0,
+    goal: null, name: Liberia}
+  model: peacecorps.account
+  pk: 30
+- fields: {category: coun, code: 249-CFD, community_contribution: null, current: 0,
+    goal: null, name: Macedonia}
+  model: peacecorps.account
+  pk: 31
+- fields: {category: coun, code: 684-CFD, community_contribution: null, current: 0,
+    goal: null, name: Madagascar}
+  model: peacecorps.account
+  pk: 32
+- fields: {category: coun, code: 614-CFD, community_contribution: null, current: 0,
+    goal: null, name: Malawi}
+  model: peacecorps.account
+  pk: 33
+- fields: {category: coun, code: 510-CFD, community_contribution: null, current: 0,
+    goal: null, name: Mexico}
+  model: peacecorps.account
+  pk: 34
+- fields: {category: coun, code: 401-CFD, community_contribution: null, current: 0,
+    goal: null, name: Micronesia}
+  model: peacecorps.account
+  pk: 35
+- fields: {category: coun, code: 261-CFD, community_contribution: null, current: 0,
+    goal: null, name: Moldova}
+  model: peacecorps.account
+  pk: 36
+- fields: {category: coun, code: 309-CFD, community_contribution: null, current: 0,
+    goal: null, name: Mongolia}
+  model: peacecorps.account
+  pk: 37
+- fields: {category: coun, code: 378-CFD, community_contribution: null, current: 0,
+    goal: null, name: Morocco}
+  model: peacecorps.account
+  pk: 38
+- fields: {category: coun, code: 640-CFD, community_contribution: null, current: 0,
+    goal: null, name: Mozambique}
+  model: peacecorps.account
+  pk: 39
+- fields: {category: coun, code: 697-CFD, community_contribution: null, current: 0,
+    goal: null, name: Namibia}
+  model: peacecorps.account
+  pk: 40
+- fields: {category: coun, code: 367-CFD, community_contribution: null, current: 0,
+    goal: null, name: Nepal}
+  model: peacecorps.account
+  pk: 41
+- fields: {category: coun, code: 524-CFD, community_contribution: null, current: 0,
+    goal: null, name: Nicaragua}
+  model: peacecorps.account
+  pk: 42
+- fields: {category: coun, code: 525-CFD, community_contribution: null, current: 0,
+    goal: null, name: Panama}
+  model: peacecorps.account
+  pk: 43
+- fields: {category: coun, code: 526-CFD, community_contribution: null, current: 0,
+    goal: null, name: Paraguay}
+  model: peacecorps.account
+  pk: 44
+- fields: {category: coun, code: 527-CFD, community_contribution: null, current: 0,
+    goal: null, name: Peru}
+  model: peacecorps.account
+  pk: 45
+- fields: {category: coun, code: 492-CFD, community_contribution: null, current: 0,
+    goal: null, name: Philippines}
+  model: peacecorps.account
+  pk: 46
+- fields: {category: coun, code: 696-CFD, community_contribution: null, current: 0,
+    goal: null, name: Rwanda}
+  model: peacecorps.account
+  pk: 47
+- fields: {category: coun, code: 491-CFD, community_contribution: null, current: 0,
+    goal: null, name: Samoa}
+  model: peacecorps.account
+  pk: 48
+- fields: {category: coun, code: 685-CFD, community_contribution: null, current: 0,
+    goal: null, name: Senegal}
+  model: peacecorps.account
+  pk: 49
+- fields: {category: coun, code: 636-CFD, community_contribution: null, current: 0,
+    goal: null, name: Sierra Leone}
+  model: peacecorps.account
+  pk: 50
+- fields: {category: coun, code: 674-CFD, community_contribution: null, current: 0,
+    goal: null, name: South Africa}
+  model: peacecorps.account
+  pk: 51
+- fields: {category: coun, code: 645-CFD, community_contribution: null, current: 0,
+    goal: null, name: Swaziland}
+  model: peacecorps.account
+  pk: 52
+- fields: {category: coun, code: 621-CFD, community_contribution: null, current: 0,
+    goal: null, name: Tanzania}
+  model: peacecorps.account
+  pk: 53
+- fields: {category: coun, code: 493-CFD, community_contribution: null, current: 0,
+    goal: null, name: Thailand}
+  model: peacecorps.account
+  pk: 54
+- fields: {category: coun, code: 693-CFD, community_contribution: null, current: 0,
+    goal: null, name: Togo}
+  model: peacecorps.account
+  pk: 55
+- fields: {category: coun, code: 421-CFD, community_contribution: null, current: 0,
+    goal: null, name: Tonga}
+  model: peacecorps.account
+  pk: 56
+- fields: {category: coun, code: 617-CFD, community_contribution: null, current: 0,
+    goal: null, name: Uganda}
+  model: peacecorps.account
+  pk: 57
+- fields: {category: coun, code: 343-CFD, community_contribution: null, current: 0,
+    goal: null, name: Ukraine}
+  model: peacecorps.account
+  pk: 58
+- fields: {category: coun, code: 461-CFD, community_contribution: null, current: 0,
+    goal: null, name: Vanuatu}
+  model: peacecorps.account
+  pk: 59
+- fields: {category: coun, code: 611-CFD, community_contribution: null, current: 0,
+    goal: null, name: Zambia}
+  model: peacecorps.account
+  pk: 60
+- fields:
+    account: 5
+    call: null
+    campaigntype: coun
+    description: Contributions to the Azerbaijan Country Fund will support Volunteer
+      and community projects that will take place in Azerbaijan. These projects often
+      focus on developing the skills of youth, but may also cover other pressing needs
+      determined by the community.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Azerbaijan
+    slug: azerbaijan
+    tagline: null
+  model: peacecorps.campaign
+  pk: 1
+- fields:
+    account: 6
+    call: null
+    campaigntype: coun
+    description: Contributions to the Belize Country Fund will support Volunteer and
+      community projects that will take place in Belize. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Belize
+    slug: belize
+    tagline: null
+  model: peacecorps.campaign
+  pk: 2
+- fields:
+    account: 7
+    call: null
+    campaigntype: coun
+    description: Contributions to the Benin Country Fund will support Volunteer and
+      community projects in education, health, environment and small business. The
+      fund also supports initiatives, such as Gender and Development (GAD), which
+      cover all sectors. You can earmark your contribution to support girls' empowerment
+      camps and/or girls' scholarships and other GAD activities.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Benin
+    slug: benin
+    tagline: null
+  model: peacecorps.campaign
+  pk: 3
+- fields:
+    account: 3
+    call: null
+    campaigntype: coun
+    description: Contributions to the Albania Country Fund will support Volunteer
+      and community projects that will take place in Albania. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Albania
+    slug: albania
+    tagline: null
+  model: peacecorps.campaign
+  pk: 4
+- fields:
+    account: 4
+    call: null
+    campaigntype: coun
+    description: Contributions to the Armenia Country Fund will support Volunteer
+      and community projects that will take place in Armenia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Armenia
+    slug: armenia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 5
+- fields:
+    account: 8
+    call: null
+    campaigntype: coun
+    description: Contributions to the Botswana Country Fund will support Volunteer
+      and community projects that will take place in Botswana. These projects support
+      reducing transmission of HIV and minimizing the impact of HIV and AIDS on individuals
+      and communities.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Botswana
+    slug: botswana
+    tagline: null
+  model: peacecorps.campaign
+  pk: 6
+- fields:
+    account: 9
+    call: null
+    campaigntype: coun
+    description: Contributions to the Burkina Faso Country Fund will support Volunteer
+      and community projects that will take place in Burkina Faso. These projects
+      include water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Burkina Faso
+    slug: burkina-faso
+    tagline: null
+  model: peacecorps.campaign
+  pk: 7
+- fields:
+    account: 10
+    call: null
+    campaigntype: coun
+    description: Contributions to the Cambodia Country Fund will support Volunteer
+      and community projects that will take place in Cambodia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Cambodia
+    slug: cambodia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 8
+- fields:
+    account: 11
+    call: null
+    campaigntype: coun
+    description: Contributions to the Cameroon Country Fund will support Volunteer
+      and community projects that will take place in Cameroon. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Cameroon
+    slug: cameroon
+    tagline: null
+  model: peacecorps.campaign
+  pk: 9
+- fields:
+    account: 12
+    call: null
+    campaigntype: coun
+    description: Contributions to the China Country Fund will support Volunteer and
+      community projects that will take place in China. These projects are largely
+      built around the volunteer's assignment teaching English on university campuses.
+      Volunteer project activities include creating or expanding English Language
+      Resource rooms, programs to develop critical thinking skills, and teacher training
+      workshops. Volunteers also develop projects with focal areas that fall under
+      Peace Corps initiatives such as women in development and HIV/AIDS awareness.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: China
+    slug: china
+    tagline: null
+  model: peacecorps.campaign
+  pk: 10
+- fields:
+    account: 13
+    call: null
+    campaigntype: coun
+    description: Contributions to the Colombia Country Fund will support Volunteer
+      and community projects that will take place in Colombia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Colombia
+    slug: colombia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 11
+- fields:
+    account: 14
+    call: null
+    campaigntype: coun
+    description: 'Contributions made to the Costa Rica Country Fund will support Volunteers
+      and their community partners with Children, Youth and Family; Community Economic
+      Development; and Rural Community Development projects. The types of projects
+      for which Volunteers and their communities solicit vary based on the unique
+      needs and priorities of their communities. Common Costa Rica projects include:
+      sports development camps and equipment, HIV/AIDS awareness and prevention workshops,
+      public infrastructure development including clinics and school playgrounds,
+      classrooms, sports fields, libraries, and computer labs; and capacity building
+      activities that develop knowledge and skills in one or more of the following
+      areas: youth development, gender empowerment, business, fine arts, performing
+      arts, music, English, information and communications technology, and life skills.'
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Costa Rica
+    slug: costa-rica
+    tagline: null
+  model: peacecorps.campaign
+  pk: 12
+- fields:
+    account: 15
+    call: null
+    campaigntype: coun
+    description: Contributions to the Dominican Republic Country Fund will support
+      Volunteer and community projects that will take place in Dominican Republic.
+      These projects include water and sanitation, agricultural development, and youth
+      programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Dominican Republic
+    slug: dominican-republic
+    tagline: null
+  model: peacecorps.campaign
+  pk: 13
+- fields:
+    account: 301
+    call: null
+    campaigntype: coun
+    description: Contributions to the Eastern Caribbean Country Fund will
+      support Volunteer and community projects that will take place in Eastern
+      Caribbean. These projects include water and sanitation, agricultural
+      development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Eastern Caribbean
+    slug: easter-caribbean
+    tagline: null
+  model: peacecorps.campaign
+  pk: 301
+- fields:
+    account: 16
+    call: null
+    campaigntype: coun
+    description: Contributions to the Ecuador Country Fund will support Volunteer
+      and community projects that will take place in Ecuador. These projects support
+      our program work in Community Health, Natural Resources Conservation, Teaching
+      English as a Foreign Language (TEFL), and Youth & Families Development.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Ecuador
+    slug: ecuador
+    tagline: null
+  model: peacecorps.campaign
+  pk: 14
+- fields:
+    account: 17
+    call: null
+    campaigntype: coun
+    description: Contributions to the El Salvador Country Fund will support Volunteer
+      and community projects that will take place in El Salvador. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: El Salvador
+    slug: el-salvador
+    tagline: null
+  model: peacecorps.campaign
+  pk: 15
+- fields:
+    account: 18
+    call: null
+    campaigntype: coun
+    description: Contributions to the Ethiopia Country Fund will support Volunteer
+      and community projects that will take place in Ethiopia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Ethiopia
+    slug: ethiopia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 16
+- fields:
+    account: 19
+    call: null
+    campaigntype: coun
+    description: Contributions to the Fiji Country Fund will support Volunteer and
+      community projects that will take place in Fiji. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Fiji
+    slug: fiji
+    tagline: null
+  model: peacecorps.campaign
+  pk: 17
+- fields:
+    account: 304
+    call: null
+    campaigntype: coun
+    description: Contributions to the Gambia Country Fund will support
+      Volunteer and community projects that will take place in the Gambia.
+      These projects include water and sanitation, agricultural development,
+      and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Gambia
+    slug: gambia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 304
+- fields:
+    account: 20
+    call: null
+    campaigntype: coun
+    description: Contributions to the Georgia Country Fund will support Volunteer
+      and community projects that will take place in Georgia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Georgia
+    slug: georgia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 18
+- fields:
+    account: 21
+    call: null
+    campaigntype: coun
+    description: Contributions to the Ghana Country Fund will support Volunteer and
+      community projects that will take place in Ghana. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Ghana
+    slug: ghana
+    tagline: null
+  model: peacecorps.campaign
+  pk: 19
+- fields:
+    account: 22
+    call: null
+    campaigntype: coun
+    description: Contributions to the Guatemala Country Fund will support Volunteer
+      and community projects that will take place in Guatemala. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Guatemala
+    slug: guatemala
+    tagline: null
+  model: peacecorps.campaign
+  pk: 20
+- fields:
+    account: 23
+    call: null
+    campaigntype: coun
+    description: Contributions to the Guinea Country Fund will support Volunteer and
+      community projects that will take place in Guinea. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Guinea
+    slug: guinea
+    tagline: null
+  model: peacecorps.campaign
+  pk: 21
+- fields:
+    account: 24
+    call: null
+    campaigntype: coun
+    description: Contributions to the Guyana Country Fund will support Volunteer and
+      community projects that will take place in Guyana. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Guyana
+    slug: guyana
+    tagline: null
+  model: peacecorps.campaign
+  pk: 22
+- fields:
+    account: 25
+    call: null
+    campaigntype: coun
+    description: Contributions to the Indonesia Country Fund will support Volunteer
+      and community projects that will take place in Indonesia. These projects will
+      focus on English education and other pressing needs determined by the community.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Indonesia
+    slug: indonesia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 23
+- fields:
+    account: 26
+    call: null
+    campaigntype: coun
+    description: Contributions to the Jamaica Country Fund will support Volunteer
+      and community projects that will take place in Jamaica. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Jamaica
+    slug: jamaica
+    tagline: null
+  model: peacecorps.campaign
+  pk: 24
+- fields:
+    account: 27
+    call: null
+    campaigntype: coun
+    description: Contributions to the Jordan Country Fund will support Volunteer and
+      community projects that will take place in Jordan. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Jordan
+    slug: jordan
+    tagline: null
+  model: peacecorps.campaign
+  pk: 25
+- fields:
+    account: 302
+    call: null
+    campaigntype: coun
+    description: Contributions to the Kosovo Country Fund will support
+      Volunteer and community projects that will take place in Kosovo. These
+      projects will focus on English education and other pressing needs
+      determined by the community.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Kosovo
+    slug: kosovo
+    tagline: null
+  model: peacecorps.campaign
+  pk: 302
+- fields:
+    account: 303
+    call: null
+    campaigntype: coun
+    description: Contributions to the Kosovo Country Fund will support
+      Volunteer and community projects that will take place in Kosovo. These
+      projects will focus on English education and other pressing needs
+      determined by the community.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Kyrgyz Republic
+    slug: kyrgyz-republic
+    tagline: null
+  model: peacecorps.campaign
+  pk: 303
+- fields:
+    account: 29
+    call: null
+    campaigntype: coun
+    description: Contributions to the Lesotho Country Fund will support Volunteer
+      and community projects that will take place in Lesotho. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Lesotho
+    slug: lesotho
+    tagline: null
+  model: peacecorps.campaign
+  pk: 26
+- fields:
+    account: 30
+    call: null
+    campaigntype: coun
+    description: Contributions to the Liberia Country Fund will support Volunteer
+      and community projects that will take place in Liberia. These projects include
+      secondary education and HIV/AIDS prevention and education programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Liberia
+    slug: liberia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 27
+- fields:
+    account: 31
+    call: null
+    campaigntype: coun
+    description: Contributions to the Macedonia Country Fund will support Volunteer
+      and community projects that will take place in Macedonia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Macedonia
+    slug: macedonia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 28
+- fields:
+    account: 32
+    call: null
+    campaigntype: coun
+    description: Contributions to the Madagascar Country Fund will support Volunteer
+      and community projects that will take place in Madagascar. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Madagascar
+    slug: madagascar
+    tagline: null
+  model: peacecorps.campaign
+  pk: 29
+- fields:
+    account: 33
+    call: null
+    campaigntype: coun
+    description: Contributions to the Malawi Country Fund will support many varied
+      Volunteer projects in Malawi. Malawi is one of the poorest countries in the
+      world. Malawi is one of the poorest countries in the world. Apart from poverty,
+      Malawi is also heavily hit by HIV/AIDS. Typical projects include water and sanitation,
+      agricultural development, Income Generation Activities, youth and HIV/AIDS related
+      programs. Many such projects fail to materialise or be implemented better due
+      to lack of resources or the time/effort it takes to get them. You can make a
+      big difference for both the work of the volunteers and people of Malawi by contributions
+      to the Malawi Country Fund, which is designed for faster response to the Volunteers
+      and their communities. An example of country fund use was funding a local mini-camp
+      for a Volunteer's community, using resources and people that were trained at
+      one of the national camps, like Camp GLOW or Camp Sky. These can happen frequently
+      as $300 - $800 is above easy Volunteer fund raising, but it goes a long way
+      in developing motivation/skills of a local group of 30 young women or youth.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Malawi
+    slug: malawi
+    tagline: null
+  model: peacecorps.campaign
+  pk: 30
+- fields:
+    account: 34
+    call: null
+    campaigntype: coun
+    description: Contributions to the Mexico Country Fund will support Volunteer and
+      community projects that will take place in Mexico. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Mexico
+    slug: mexico
+    tagline: null
+  model: peacecorps.campaign
+  pk: 31
+- fields:
+    account: 35
+    call: null
+    campaigntype: coun
+    description: Contributions to the Micronesia Country Fund will support Volunteer
+      and community projects that will take place in Micronesia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Micronesia
+    slug: micronesia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 32
+- fields:
+    account: 36
+    call: null
+    campaigntype: coun
+    description: Contributions to the Moldova Country Fund will support Volunteer
+      and community projects that will take place in Moldova. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Moldova
+    slug: moldova
+    tagline: null
+  model: peacecorps.campaign
+  pk: 33
+- fields:
+    account: 37
+    call: null
+    campaigntype: coun
+    description: Contributions to the Mongolia Country Fund will support Volunteer
+      and community projects that will take place in Mongolia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Mongolia
+    slug: mongolia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 34
+- fields:
+    account: 38
+    call: null
+    campaigntype: coun
+    description: Contributions to the Morocco Country Fund will support Volunteer
+      and community projects that will take place in Morocco. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Morocco
+    slug: morocco
+    tagline: null
+  model: peacecorps.campaign
+  pk: 35
+- fields:
+    account: 39
+    call: null
+    campaigntype: coun
+    description: Contributions to the Mozambique Country Fund will support Volunteer
+      and community projects that will take place in Mozambique. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Mozambique
+    slug: mozambique
+    tagline: null
+  model: peacecorps.campaign
+  pk: 36
+- fields:
+    account: 40
+    call: null
+    campaigntype: coun
+    description: Contributions to the Namibia Country Fund will support Volunteer
+      and community projects that will take place in Namibia. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Namibia
+    slug: namibia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 37
+- fields:
+    account: 41
+    call: null
+    campaigntype: coun
+    description: Contributions to the Nepal Country Fund will support approved Volunteer
+      and community PCPP projects that will take place in Nepal. Volunteer projects
+      typically focus on food security components like nutrition, health, agriculture,
+      water sanitation and hygiene and income generation, but may also address other
+      important needs as determined by the community.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Nepal
+    slug: nepal
+    tagline: null
+  model: peacecorps.campaign
+  pk: 38
+- fields:
+    account: 42
+    call: null
+    campaigntype: coun
+    description: Contributions to the Nicaragua Country Fund will support Volunteer
+      and community projects that will take place in Nicaragua. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Nicaragua
+    slug: nicaragua
+    tagline: null
+  model: peacecorps.campaign
+  pk: 39
+- fields:
+    account: 43
+    call: null
+    campaigntype: coun
+    description: 'Contributions to the Panama Country Fund will support Volunteers
+      and their community partners to implement on-going development projects in one
+      of our 5 programs: Sustainable Agriculture, Environmental Conservation, Tourism
+      and English Advising, Economic Development and Environmental Health. Within
+      these projects, Peace Corps Partnership Program supported activities and workshops
+      focus on critical areas of leadership development, project management, HIIV/AIDS
+      awareness, business plan design, and youth development. With your help, Volunteers
+      and community counterparts from all over the country are able to come together
+      to share and develop best practices for use in their own communities.'
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Panama
+    slug: panama
+    tagline: null
+  model: peacecorps.campaign
+  pk: 40
+- fields:
+    account: 44
+    call: null
+    campaigntype: coun
+    description: Contributions to the Paraguay Country Fund will support Volunteer
+      and community projects that will take place in Paraguay. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Paraguay
+    slug: paraguay
+    tagline: null
+  model: peacecorps.campaign
+  pk: 41
+- fields:
+    account: 45
+    call: null
+    campaigntype: coun
+    description: Contributions to the Peru Country Fund will support Volunteer and
+      community projects that will take place in Peru. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Peru
+    slug: peru
+    tagline: null
+  model: peacecorps.campaign
+  pk: 42
+- fields:
+    account: 46
+    call: null
+    campaigntype: coun
+    description: 'Contributions to the Philippines Country Fund will support Volunteer
+      and community projects in the Philippines.These development projects include,
+      but are not limited to the following: English language and basic education,
+      library development, alternative livelihood, HIV/AIDS and health, environmental
+      education, coastal resources development, capacity building, life skills, and
+      youth empowerment.'
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Philippines
+    slug: philippines
+    tagline: null
+  model: peacecorps.campaign
+  pk: 43
+- fields:
+    account: 47
+    call: null
+    campaigntype: coun
+    description: Contributions to the Rwanda Country Fund will support Volunteer and
+      community projects that will take place in Rwanda. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Rwanda
+    slug: rwanda
+    tagline: null
+  model: peacecorps.campaign
+  pk: 44
+- fields:
+    account: 48
+    call: null
+    campaigntype: coun
+    description: Contributions to the Samoa Country Fund will support Volunteer and
+      community projects that will take place in Samoa. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Samoa
+    slug: samoa
+    tagline: null
+  model: peacecorps.campaign
+  pk: 45
+- fields:
+    account: 49
+    call: null
+    campaigntype: coun
+    description: Contributions to the Senegal Country Fund will support Volunteer
+      and community projects that will take place in Senegal. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Senegal
+    slug: senegal
+    tagline: null
+  model: peacecorps.campaign
+  pk: 46
+- fields:
+    account: 50
+    call: null
+    campaigntype: coun
+    description: Contributions to the Sierra Leone Country Fund will support Volunteer
+      and community projects that will take place in Sierra Leone. These projects
+      will focus on English education and other pressing needs determined by the community.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Sierra Leone
+    slug: sierra-leone
+    tagline: null
+  model: peacecorps.campaign
+  pk: 47
+- fields:
+    account: 51
+    call: null
+    campaigntype: coun
+    description: Contributions to the South Africa Country Fund will support Volunteer
+      and community projects that will take place in South Africa. These projects
+      include water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: South Africa
+    slug: south-africa
+    tagline: null
+  model: peacecorps.campaign
+  pk: 48
+- fields:
+    account: 52
+    call: null
+    campaigntype: coun
+    description: Contributions to the Swaziland Country Fund will support Volunteer
+      and community projects that will take place in Swaziland. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Swaziland
+    slug: swaziland
+    tagline: null
+  model: peacecorps.campaign
+  pk: 49
+- fields:
+    account: 53
+    call: null
+    campaigntype: coun
+    description: Contributions to the Tanzania Country Fund will support Volunteer
+      and community projects that will take place in Tanzania. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Tanzania
+    slug: tanzania
+    tagline: null
+  model: peacecorps.campaign
+  pk: 50
+- fields:
+    account: 54
+    call: null
+    campaigntype: coun
+    description: Contributions to the Thailand Country Fund will support Volunteer
+      and community projects that will take place in Thailand. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Thailand
+    slug: thailand
+    tagline: null
+  model: peacecorps.campaign
+  pk: 51
+- fields:
+    account: 55
+    call: null
+    campaigntype: coun
+    description: Contributions to the Togo Country Fund will support Volunteer and
+      community projects that will take place in Togo. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Togo
+    slug: togo
+    tagline: null
+  model: peacecorps.campaign
+  pk: 52
+- fields:
+    account: 56
+    call: null
+    campaigntype: coun
+    description: Contributions to the Tonga Country Fund will support Volunteer and
+      community projects that will take place in Tonga.These projects include youth
+      development, school library development, environmental education, public health
+      and IT education.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Tonga
+    slug: tonga
+    tagline: null
+  model: peacecorps.campaign
+  pk: 53
+- fields:
+    account: 57
+    call: null
+    campaigntype: coun
+    description: Contributions to the Uganda Country Fund will support Volunteer and
+      community projects that will take place in Uganda. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Uganda
+    slug: uganda
+    tagline: null
+  model: peacecorps.campaign
+  pk: 54
+- fields:
+    account: 58
+    call: null
+    campaigntype: coun
+    description: Contributions to the Ukraine Country Fund will support Volunteer
+      and community projects that will take place in Ukraine. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Ukraine
+    slug: ukraine
+    tagline: null
+  model: peacecorps.campaign
+  pk: 55
+- fields:
+    account: 59
+    call: null
+    campaigntype: coun
+    description: Contributions to the Vanuatu Country Fund will support Volunteer
+      and community projects that will take place in Vanuatu. These projects include
+      water and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Vanuatu
+    slug: vanuatu
+    tagline: null
+  model: peacecorps.campaign
+  pk: 56
+- fields:
+    account: 60
+    call: null
+    campaigntype: coun
+    description: Contributions to the Zambia Country Fund will support Volunteer and
+      community projects that will take place in Zambia. These projects include water
+      and sanitation, agricultural development, and youth programs.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Zambia
+    slug: zambia
+    tagline: null
+  model: peacecorps.campaign
+  pk: 57
+- fields:
+    account: 28
+    call: null
+    campaigntype: coun
+    description: "<p>Contributions to the Kenya Country Fund will support Volunteer
+      Community projects in Kenya. The scope of projects to be funded would likely
+      fall within education, water/sanitation, health, agriculture, youth development,
+      vocational/special education and income-generating activities.&nbsp;</p>\r\n<p>Peace
+      Corps supports Kenya's goals of poverty eradication and industrialization as
+      well as Kenya's commitment to fight HIV/AIDS and malaria. Peace Corps Kenya's
+      current programs include Education (including Deaf Education), Public Health
+      and Small Enterprise Development/Information and Communications Technology.&nbsp;</p>\r\n<p>Insecurity,
+      poor infrastructure, access to clean water especially in rural areas, and adverse
+      poverty continues to be Kenya's major challenges. Changes in weather patterns
+      and high farming costs have compromised farmers' ability to plant and grow adequate
+      food, resulting in shortages of food and hunger in some parts of Kenya. The
+      demand for food continues to increase household poverty levels with more than
+      half of Kenyans (56%) living below the poverty level.&nbsp;</p>\r\n<p>HIV/AIDS
+      is another major social, economic and health problem in Kenya. Many young and
+      productive Kenyans die daily as a result of AIDS. Much productive time and resources
+      are spent in care and treatment for AIDS patients. The situation is worsened
+      when the patient is the household breadwinner.&nbsp;</p>\r\n<p>In addressing
+      these prevalent Kenya community needs, Peace Corps volunteers work hand in hand
+      with their Kenyan community counterparts in engaging the community to identify
+      their priority needs and possible interventions. The community also identifies
+      local resources and gaps within which external assistance is required.</p>"
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Kenya
+    slug: kenya
+    tagline: null
+  model: peacecorps.campaign
+  pk: 58
+

--- a/peacecorps/peacecorps/fixtures/issues.yaml
+++ b/peacecorps/peacecorps/fixtures/issues.yaml
@@ -1,0 +1,272 @@
+- fields: {category: iss, code: SPF-AGG, community_contribution: null, current: 0,
+    goal: null, name: Agriculture}
+  model: peacecorps.account
+  pk: 61
+- fields: {category: iss, code: SPF-BUS, community_contribution: null, current: 0,
+    goal: null, name: Business Development}
+  model: peacecorps.account
+  pk: 62
+- fields: {category: iss, code: SPF-WAT, community_contribution: null, current: 0,
+    goal: null, name: Water and Sanitation}
+  model: peacecorps.account
+  pk: 63
+- fields: {category: iss, code: SPF-EDU, community_contribution: null, current: 0,
+    goal: null, name: Education}
+  model: peacecorps.account
+  pk: 64
+- fields: {category: iss, code: SPF-ENV, community_contribution: null, current: 0,
+    goal: null, name: Environment}
+  model: peacecorps.account
+  pk: 65
+- fields: {category: iss, code: SPF-HHA, community_contribution: null, current: 0,
+    goal: null, name: Health}
+  model: peacecorps.account
+  pk: 66
+- fields: {category: iss, code: SPF-ICT, community_contribution: null, current: 0,
+    goal: null, name: Information Technology}
+  model: peacecorps.account
+  pk: 67
+- fields: {category: iss, code: SPF-YTH, community_contribution: null, current: 0,
+    goal: null, name: Youth}
+  model: peacecorps.account
+  pk: 68
+- fields:
+    account: 64
+    call: Support Education Projects
+    campaigntype: sec
+    description: Throughout the developing world, Peace Corps Volunteers are working
+      in their communities to share the precious gift of education. Often Volunteers'
+      dedication to teaching is matched by a severe lack of supplies and facilities
+      in which to help. Contributions to this fund will help Volunteer and community
+      projects such as school construction, English language training, school and
+      library material, and adult literacy.
+    featured_image: 11
+    featuredprojects: []
+    icon: 26
+    name: Education
+    slug: education
+    tagline: Peace Corps Volunteers are working in their communities to share the
+      precious gift of education.
+  model: peacecorps.campaign
+  pk: 69
+- fields:
+    account: 68
+    call: Support Youth Projects
+    campaigntype: sec
+    description: In communities that face very basic struggles, the specific needs
+      of children and young adults often go unaddressed. Peace Corps Volunteers work
+      with local youths to improve their education opportunities, make them aware
+      of health and cultural issues they will face, and engage them in activities
+      that will help them grow. Contributions to this fund will help Volunteer and
+      community projects such as camps, recreation centers, and after school clubs
+      and sports.
+    featured_image: 11
+    featuredprojects: []
+    icon: 22
+    name: Youth
+    slug: youth
+    tagline: Improve education and health for children and youth around the world.
+  model: peacecorps.campaign
+  pk: 70
+- fields:
+    account: 67
+    call: Support Technology Projects
+    campaigntype: sec
+    description: Peace Corps Volunteers are working with men and women in communities
+      throughout the developing world to help them gain access to information technology
+      skills and resources. Consistent with all Peace Corps volunteer work, their
+      efforts are aimed at the promotion of social and economic development and the
+      reduction of poverty. To this aim, volunteers are using IT to enhance existing
+      small, local entrepreneurial efforts, in order to allow once isolated communities
+      to link to the world and find and capitalize on opportunities once completely
+      out of their reach. Contributions to this fund will support Community and Volunteer
+      projects such as creating school and public computer labs and teaching computer
+      skills.
+    featured_image: 14
+    featuredprojects: []
+    icon: 23
+    name: Technology
+    slug: technology
+    tagline: Enhance existing local entrepreneurial efforts, create school and public
+      computer labs, and teaching computer skills.
+  model: peacecorps.campaign
+  pk: 71
+- fields:
+    account: 66
+    call: Support Health Projects
+    campaigntype: sec
+    description: Donations to the Health and HIV/AIDS Fund will help combat global
+      health issues such as poor nutrition, the spread of infectious diseases, and
+      the devastating social and economic impact of HIV/AIDS. In order to help alleviate
+      these problems, Volunteers and their host communities are planning and implementing
+      projects which focus on preventative health care, nutrition, and disease prevention
+      and mitigation. The range of activities includes immunizations; nutrition and
+      growth monitoring; promotion of breast-feeding; access to prenatal and postnatal
+      care; training health workers; development of public awareness material; and
+      culturally appropriate education strategies.
+    featured_image: 13
+    featuredprojects: []
+    icon: 24
+    name: Health
+    slug: health
+    tagline: Combat global health issues such as poor nutrition, the spread of infectious
+      diseases, and the devastating impact of HIV/AIDS.
+  model: peacecorps.campaign
+  pk: 72
+- fields:
+    account: 65
+    call: Support Environmental Projects
+    campaigntype: sec
+    description: Communities around the world are challenged by the need to improve
+      their development in an environmentally sustainable way. Peace Corps Volunteers
+      are working with their communities to show that sustainable environmental management
+      is not only good stewardship, but can be an engine of future economic growth.
+      Contributions to this fund will help Volunteer and community projects such as
+      environmental conservation and ecotourism.
+    featured_image: 12
+    featuredprojects: []
+    icon: 25
+    name: Environment Fund
+    slug: environment-fund
+    tagline: 'Environmental stewardship spurs economic growth. '
+  model: peacecorps.campaign
+  pk: 73
+- fields:
+    account: 63
+    call: Support Water Projects
+    campaigntype: sec
+    description: <p>The very basic needs of clean water and accessible sanitation
+      are absent from many communities around the world. This often leads to severe
+      community health problems. Volunteers work with their communities to design
+      locally appropriate solutions to provide safe, affordable, and sustainable water
+      and sanitation. Contributions to this fund will help Volunteer and community
+      projects such as latrines, aqueducts and wells, and basic sanitation training.</p>
+    featured_image: 10
+    featuredprojects: []
+    icon: 27
+    name: Drinking Water and Sanitation
+    slug: drinking-water-and-sanitation-fund
+    tagline: Safe, affordable, and sustainable water and sanitation are vital to communities
+      worldwide.
+  model: peacecorps.campaign
+  pk: 74
+- fields:
+    account: 62
+    call: Support Business Development Projects
+    campaigntype: sec
+    description: Volunteers are posted throughout the developing world to help local
+      businesses thrive in ways they never thought possible. Increasing the opportunities
+      presented to local businesses promotes a sense of empowerment that can truly
+      change a community. Contributions to this fund will support Volunteer and community
+      projects such as microfinance, agribusiness, business education, and artisan
+      collectives.
+    featured_image: 9
+    featuredprojects: []
+    icon: 28
+    name: Business Development
+    slug: business-development
+    tagline: Increasing opportunities for local businesses promotes a sense of empowerment
+      that can transform a community.
+  model: peacecorps.campaign
+  pk: 75
+- fields:
+    account: 61
+    call: Support Agriculture Projects
+    campaigntype: sec
+    description: "Contributions to the Agriculture Fund support one of the most basic
+      needs of communities worldwide: safe and sustainable food production. Agriculture
+      projects target areas such as community food production systems, pesticide safety,
+      crop production, animal husbandry, apiculture, agriculture marketing, farm economics,
+      and formation of agricultural cooperatives. As food security continues to be
+      a global concern, it is imperative to support communities' agricultural development.\r\n"
+    featured_image: 8
+    featuredprojects: []
+    icon: 29
+    name: Agriculture
+    slug: agriculture
+    tagline: Safe and sustainable food production is one of the most basic needs of
+      communities worldwide.
+  model: peacecorps.campaign
+  pk: 76
+- fields: {caption: 'Water buffalo pulling a plow in Indonesia. Photo by wikipedia
+      user Merbabu, CC-BY-SA 3.0', country: 79, description: A picture of water buffalo
+      pulling a plow., file: ./Agriculture-wikipedia-user-merbabu-cc-by-sa-3.jpg,
+    mediatype: IMG, title: Agriculture, transcript: ''}
+  model: peacecorps.media
+  pk: 8
+- fields: {caption: 'A meeting to discuss microfinance in Tzaneen, South Africa. Picture
+      by GiveWell, CC-BY.', country: 160, description: 'Women sitting on a blanket
+      and discussing microfinance on a patio in Tzaneen, South Africa.', file: ./Tzaneen-South-Africa-Microfinance-Meeting-by-GiveWell-CC-BY.jpg,
+    mediatype: IMG, title: 'Microfinance Meeting, Tzaneen, South Africa', transcript: ''}
+  model: peacecorps.media
+  pk: 9
+- fields: {caption: 'An iceberg near Upernavik, Greenland. Photo by Kim Hansen, CC-BY-SA',
+    country: 77, description: An iceberg in a large body of water., file: ./Iceburg-near-Upernavik-Greenland-by-Kim-Hansen-CC-BY-SA.jpg,
+    mediatype: IMG, title: 'Iceberg near Upernavik, Greenland', transcript: ''}
+  model: peacecorps.media
+  pk: 10
+- fields: {caption: 'Schoolgirls sitting in the shade on a patio in Bamozai, Afghanistan.
+      Photo by Capt. John Severns, U.S. Air Force (Public Domain)', country: 2, description: 'Schoolgirls
+      sitting on a patio in Bamozai, Afghanistan.', file: ./Schoolgirls-in-Bamozai-Afghanistan-by-Capt-John-Severns-PD.jpg,
+    mediatype: IMG, title: Schoolgirls in Bamozai Afghanistan, transcript: ''}
+  model: peacecorps.media
+  pk: 11
+- fields: {caption: A woman in Guatamala holds a bunch of radishes in this photo by
+      a Peace Corps volunteer., country: 69, description: A woman stands in a public
+      square in Guatamala with a bunch of radishes., file: ./Guatamala-by-peacecorps.jpg,
+    mediatype: IMG, title: Guatamala Radishes, transcript: ''}
+  model: peacecorps.media
+  pk: 12
+- fields: {caption: Health volunteers sworn in in Gambia., country: null, description: A
+      group of Peace Corps health volunteers in Gambia., file: ./Gambia-Health-Volunteers-by-peacecorps.jpg,
+    mediatype: IMG, title: Health Volunteers in Gambia, transcript: ''}
+  model: peacecorps.media
+  pk: 13
+- fields: {caption: 'Peace Corps volunteer Sam teaching reading in El Progreso, El
+      Salvador', country: 55, description: A peace corps volunteer helping a Salvadoran
+      girl with a computer program., file: ./Rubidia-learns-to-read-by-Lee-Shaver-CC-BY-SA.jpg,
+    mediatype: IMG, title: Rubidia Learns To Read, transcript: ''}
+  model: peacecorps.media
+  pk: 14
+- fields: {caption: Children by Sarah Rudkin., country: null, description: an icon
+      of children holding hands., file: ./Children-by-Sarah-Rudkin-CC-BY-3.png, mediatype: IMG,
+    title: Children Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 22
+- fields: {caption: image by Marwa Boukarim., country: null, description: Simple graphic
+      of a phone., file: ./Cell-Phone-Icon-By-Marwa-Boukarim-CC-BY.png, mediatype: IMG,
+    title: Cell Phone Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 23
+- fields: {caption: 'Health by Christopher Holm-Hansen, CC-BY', country: null, description: Icon
+      of a heart with a heartbeat line, file: ./Health-by-Christopher-Holm-Hansen-CC-BY.png,
+    mediatype: IMG, title: Health Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 24
+- fields: {caption: 'World icon by Ana Maria Lora Macias, CC-BY', country: null, description: An
+      icon of the globe., file: ./World-by-Ana-Maria-Lora-Macias-CC-BY.png, mediatype: IMG,
+    title: World Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 25
+- fields: {caption: 'Book Icon by Dmitry Baranovskiy, CC-BY', country: null, description: An
+      icon of a pair of books, file: ./Book-by-Dmitry-Baranovskiy-CC-BY.png, mediatype: IMG,
+    title: Book Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 26
+- fields: {caption: Water by Monika Ciapala, country: null, description: An icon of
+      a water droplet., file: ./Water-by-Monika-Ciapala-CC-BY.png, mediatype: IMG,
+    title: Water icon, transcript: ''}
+  model: peacecorps.media
+  pk: 27
+- fields: {caption: 'Livelihood, by OCHA Visual Information Unit. This work of the
+      United Nations Secretariat is in the public domain.', country: null, description: an
+      icon of a bowl with a wheat stalk in it in front of a bag of money., file: ./Livelihood-by-OCHA-Visual-Information-Unit-PD.png,
+    mediatype: IMG, title: Livelihood Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 28
+- fields: {caption: Agriculture by the OCHA Visual Information Unit. This work of
+      the United Nations Secretariat is in the public domain., country: null, description: An
+      icon of two stalks of wheat., file: ./Agriculture-by-OCHA-Visual-Information-Unit-PD.png,
+    mediatype: IMG, title: Agriculture Icon, transcript: ''}
+  model: peacecorps.media
+  pk: 29

--- a/peacecorps/peacecorps/fixtures/memorial.yaml
+++ b/peacecorps/peacecorps/fixtures/memorial.yaml
@@ -1,0 +1,196 @@
+- fields: {category: mem, code: SPF-ALF, community_contribution: null, current: 0,
+    goal: null, name: Alden Landis Memorial}
+  model: peacecorps.account
+  pk: 201
+- fields: {category: mem, code: SPF-CPF, community_contribution: null, current: 0,
+    goal: null, name: Craig Pollock Memorial}
+  model: peacecorps.account
+  pk: 202
+- fields: {category: mem, code: SPF-DDF, community_contribution: null, current: 0,
+    goal: null, name: 'Danielle "Dani" Dunlap Memorial'}
+  model: peacecorps.account
+  pk: 203
+- fields: {category: mem, code: SPF-EBF, community_contribution: null, current: 0,
+    goal: null, name: Emily Balog Memorial}
+  model: peacecorps.account
+  pk: 204
+- fields: {category: mem, code: SPF-KPF, community_contribution: null, current: 0,
+    goal: null, name: Kate Puzey Memorial}
+  model: peacecorps.account
+  pk: 205
+- fields: {category: mem, code: SPF-LJF, community_contribution: null, current: 0,
+    goal: null, name: Lena Jenison Memorial}
+  model: peacecorps.account
+  pk: 206
+- fields: {category: mem, code: SPF-PKF, community_contribution: null, current: 0,
+    goal: null, name: Porter Knight Memorial}
+  model: peacecorps.account
+  pk: 207
+- fields: {category: mem, code: SPF-GND, community_contribution: null, current: 0,
+    goal: null, name: Ruppe Gender Development}
+  model: peacecorps.account
+  pk: 208
+- fields: {category: mem, code: SPF-SCF, community_contribution: null, current: 0,
+    goal: null, name: Stephanie Chance Memorial}
+  model: peacecorps.account
+  pk: 209
+- fields:
+    account: 201
+    call: Support Projects in Mozambique
+    campaigntype: mem
+    description: All donations to the Alden Landis Memorial Fund will support
+      approved Peace Corps Partnership Program (PCPP) projects in Mozambique
+      including those with an emphasis on healthcare and safety.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Alden Landis Memorial
+    slug: alden-landis-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 201
+- fields:
+    account: 202
+    call: Support Projects in South America
+    campaigntype: mem
+    description: All donations to this Fund will support approved Peace Corps
+      Partnership Program (PCPP) projects in South America with a focus on
+      Health and Education.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Craig Pollock Memorial
+    slug: craig-pollock-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 202
+- fields:
+    account: 203
+    call: Support the Mama Grace Memorial Clinic
+    campaigntype: mem
+    description: Donations to this fund will be used to equip and outfit the
+      "Mama Grace Memorial Clinic" begun by Danielle; once the clinic is
+      complete, contributions will support approved Peace Corps Partnership
+      Program (PCPP) projects in Ghana for improving rural health care and
+      preventing HIV/AIDS and malaria, in furtherance of Dani's extraordinary
+      work.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: 'Danielle "Dani" Dunlap Memorial'
+    slug: danielle-dani-dunlap-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 203
+- fields:
+    account: 204
+    call: Support Projects in Paraguay
+    campaigntype: mem
+    description: All donations to the Emily Balog Memorial Fund will support
+      approved Peace Corps Partnership Program (PCPP) projects in Paraguay.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Emily Balog Memorial
+    slug: emily-balog-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 204
+- fields:
+    account: 205
+    call: Support Young Girls in Benin
+    campaigntype: mem
+    description: The Kate Puzey Memorial Fund was established to honor the
+      memory and service of Benin Volunteer, Kate Puzey. This fund enables
+      members of the public, as well as former Volunteers who have been
+      inspired by Kate's story, to support ongoing work in her memory.
+      Donations to this fund will be used to support approved Peace Corps
+      Partnership Program (PCPP) projects which focus on the empowerment and
+      education of young girls in Benin, a cause that was very close to Kate's
+      heart. Returned Peace Corps Volunteers who received contributions from
+      the Fund for their previous PCPP projects are also welcome to contribute
+      to ensure Kate's continuing legacy.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Kate Puzey Memorial
+    slug: kate-puzey-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 205
+- fields:
+    account: 206
+    call: Support Projects in Mozambique
+    campaigntype: mem
+    description: All donations to the Lena Jenison Memorial Fund will support
+      approved Peace Corps Partnership Program (PCPP) projects in Mozambique
+      with a focus on science education.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Lena Jenison Memorial
+    slug: lena-jenison-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 206
+- fields:
+    account: 207
+    call: Support Projects in Paraguay
+    campaigntype: mem
+    description: All donations to the Porter Knight Memorial Fund will support
+      approved Peace Corps Partnership Program (PCPP) projects in Paraguay
+      that focus on the environment.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Porter Knight Memorial
+    slug: porter-knight-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 207
+- fields:
+    account: 208
+    call: Support Girls Education
+    campaigntype: mem
+    description: "Contributions to this Fund are committed to
+      community-initiated and Volunteer-led projects such as establishing
+      women's cooperatives, increasing women's access to resources and
+      services, exploring gender roles, building shelters, and increasing
+      training programs. The Loret Miller Ruppe and Loret, Jr. Fund for the
+      Advancement of Women was established to celebrate the lives of Loret
+      Miller Ruppe who was the longest serving Director in Peace Corps history
+      and Loret Jr., her daughter. Loret Miller Ruppe served as Director from
+      1981-89 and was a great, vocal advocate for the Peace Corps' mission of
+      world peace and friendship both globally and domestically. Her passion
+      for service inspired her daughter, Loret, Jr., to serve as a Peace Corps
+      Volunteer in Nepal. Their vision and hard work brought hope to
+      communities around the world, especially for women.<p />
+      To honor the outstanding contributions of Loret Miller Ruppe, this fund
+      was established with a generous grant from her family to assist Peace
+      Corps volunteers who wish to carry on the work that was so important to
+      her: the empowerment of women and girls around the world.<p />
+      To celebrate the life and service of Loret, Jr., the fund now highlights
+      projects supporting girls' education and camps for girls."
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Ruppe Gender Development
+    slug: ruppe-gender-development
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 208
+- fields:
+    account: 209
+    call: Support Projects Empowering Women
+    campaigntype: mem
+    description: All donations to this Fund will support approved Peace Corps
+      Partnership Program (PCPP) projects around the world with a focus on
+      gender, such as women's empowerment and girls education.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Stephanie Chance Memorial 
+    slug: stephanie-chance-memorial
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 209

--- a/peacecorps/peacecorps/fixtures/other-campaigns.yaml
+++ b/peacecorps/peacecorps/fixtures/other-campaigns.yaml
@@ -1,0 +1,106 @@
+- fields: {category: oth, code: PCF-GEN, community_contribution: null, current: 0,
+    goal: null, name: General}
+  model: peacecorps.account
+  pk: 76
+- fields: {category: oth, code: SPF-GBL, community_contribution: null, current: 0,
+    goal: null, name: Global}
+  model: peacecorps.account
+  pk: 101
+- fields: {category: oth, code: SPF-MDF, community_contribution: null, current: 0,
+    goal: null, name: Municipal Development}
+  model: peacecorps.account
+  pk: 102
+- fields: {category: oth, code: SPF-MLR, community_contribution: null, current: 0,
+    goal: null, name: Stomping Out Malaria in Africa}
+  model: peacecorps.account
+  pk: 103
+- fields:
+    account: 76
+    call: null
+    campaigntype: gen
+    description: "<p>This is a terrific opportunity to make a donation to the Peace
+      Corps and receive a collectible work of art by American contemporary artist
+      Shepard Fairey. This artwork depicts a Peace Corps agricultural Volunteer working
+      with a young person in Senegal. Fairey was inspired by his sister who served
+      in West Africa. Not only is this a great gift for family and friends, but your
+      donation supports the Peace Corps&rsquo; mission. First come, first served,
+      for this artwork so make your donation today!</p>\r\n<p>Why support our work?
+      One hundred percent of your contribution is tax-deductible and will advance
+      the Peace Corps mission of peace and friendship around the globe. Additionally,
+      you can donate in honor or in memory of a loved one.</p>"
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Peace Corps
+    slug: peace-corps
+    tagline: null
+  model: peacecorps.campaign
+  pk: 68
+- fields:
+    account: 101
+    call: Support Global Projects
+    campaigntype: sec
+    description: Through the generous support of donors across America, each
+      year the Peace Corps Partnership Program funds hundreds of
+      community-initiated projects all over the globe. If you are interested
+      in helping Peace Corps Volunteers and communities accomplish amazing
+      projects, but do not have a specific project in mind, you can contribute
+      to the Global Fund. Donations to the Global Fund go towards a wide
+      variety of Partnership Program projects that find that they are falling
+      short of funding from other sources. Should a project or special fund
+      receive full support from other sources or be canceled, any remaining
+      funds will automatically be directed to the Global Fund and be used for
+      Volunteer and community projects.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Global
+    slug: global
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 101
+- fields:
+    account: 102
+    call: Support Municipal Development Projects
+    campaigntype: sec
+    description: Contributions to the Municipal Development Fund will support
+      overarching capacity building across all sectors, such as health,
+      education, and waste management. Projects range from improving public
+      spaces and buildings, like classrooms, clinics, and parks to promoting
+      civic education and participation in municipal decisions. Municipal
+      projects area foundation on which communities can increase their civic
+      engagement and ultimately their overall economic development.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Municipal Development
+    slug: municipal-development
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 102
+- fields:
+    account: 103
+    call: Support Malaria Projects
+    campaigntype: sec
+    description: The Peace Corps Malaria Initiative for Africa is a targeted
+      support program for malaria prevention activities across sub-Saharan
+      Africa. Contributions to the Fund support community identified,
+      volunteer facilitated malaria prevention Peace Corps Partnership Program
+      projects such as training community health workers in malaria diagnosis
+      and treatment, creating small businesses selling mosquito repellent
+      crèmes, delivering insecticide treated nets, providing education to
+      thousands of community members on how to protect oneself from malaria
+      and many more. According to WHO statistics, Malaria kills 750,000 people
+      annually and while large scale international efforts have seen notable
+      success in the last decade, malaria is still the scourge of much of
+      Africa. Contributions to the Fund allow volunteers and their communities
+      to pilot the next round of innovative best practices which will inform
+      malaria prevention world-wide.
+    featured_image: null
+    featuredprojects: []
+    icon: null
+    name: Stomping Out Malaria in Africa
+    slug: stomping-out-malaria-africa
+    tagline: ""
+  model: peacecorps.campaign
+  pk: 103


### PR DESCRIPTION
Currently includes some non-final images and puts a few of the non-issue sector funds as "general", which may need to change.

Accounting codes are all up-to-date.

These fixtures can be used when populating the database for the first time. If you've already imported the tests.yaml fixture, you'll run into some conflicts.
