### PR TITLE
Correct a decimal, add host to redirect

### DIFF
--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -68,9 +68,10 @@ def generate_collection_request(data):
     SubElement(interactive, 'allow_account_data_change', {'value': 'True'})
 
     collection_auth = SubElement(interactive, 'collection_auth')
-    collection_fields = [
-        'agency_tracking_id', 'agency_memo', 'form_id', 'payment_amount']
+    collection_fields = ['agency_tracking_id', 'agency_memo', 'form_id']
     add_subelements(collection_auth, data, collection_fields)
+    SubElement(collection_auth, 'payment_amount',
+               {'value': "%.2f" % (data['payment_amount'] / 100.0)})
 
     account_data = SubElement(collection_auth, 'account_data')
     account_fields = [

--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -140,7 +140,7 @@ def redirect_urls(account):
                             kwargs={'slug': campaign.slug}))
 
 
-def convert_to_paygov(data, account):
+def convert_to_paygov(data, account, callback_base):
     """Convert the form data into a pay.gov model (including appropriate XML)
     and return."""
     data = dict(data)   # shallow copy
@@ -148,7 +148,8 @@ def convert_to_paygov(data, account):
     data['agency_tracking_id'] = tracking_id
     data['agency_memo'] = generate_agency_memo(data)
     data['form_id'] = settings.PAY_GOV_FORM_ID
-    data['success_url'], data['failure_url'] = redirect_urls(account)
+    data['success_url'], data['failure_url'] = (
+        callback_base + url for url in redirect_urls(account))
     data.update(generate_custom_fields(data))
     xml = generate_collection_request(data)
     return DonorInfo(agency_tracking_id=tracking_id, account=account,

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -63,7 +63,7 @@ class DonationsTests(TestCase):
 
         response = self.client.post(
             '/donations/contribute/?amount=2000&project=' + self.account.code,
-            form_data)
+            form_data, HTTP_HOST='example.com')
         content = response.content.decode('utf-8')
         self.assertEqual(200, response.status_code)
         self.assertTrue('agency_tracking_id' in content)
@@ -76,6 +76,9 @@ class DonationsTests(TestCase):
         #   Refetch the account so we can lookup its donorinfo
         account = Account.objects.get(pk=self.account.pk)
         self.assertEqual(1, len(account.donorinfos.all()))
+        #   Also verify that the http host has been added
+        donorinfo = account.donorinfos.get()
+        self.assertTrue('://example.com' in donorinfo.xml)
 
     def test_humanize_amount(self):
         """ The humanize_amount function converts an amount in cents into

--- a/peacecorps/peacecorps/tests/test_xmlgen.py
+++ b/peacecorps/peacecorps/tests/test_xmlgen.py
@@ -28,7 +28,7 @@ class PayXMLGenerationTests(TestCase):
             'agency_tracking_id': 'PCIOCI1234',
             'agency_memo': '()(5555555)',
             'form_id': 'DONORFORM',
-            'payment_amount': '20.00',
+            'payment_amount': 2000,
             'payment_type': 'CreditCard',
             'payer_name': 'William Williams',
             'billing_address': '1 Main St',

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -57,7 +57,8 @@ def donation_payment(request):
 def donation_payment_review(request, data, account):
     """Save the payment information for future access; provide the user with a
     form that sends them over to pay.gov"""
-    paygov = convert_to_paygov(data, account)
+    callback_base = request.scheme + "://" + request.get_host()
+    paygov = convert_to_paygov(data, account, callback_base)
     paygov.save()
 
     return render(


### PR DESCRIPTION
- Updates a test to use more realistic form submission data
- Fixes error which resulted in payments from pay.gov in cents rather than dollars
- Adds scheme and host to the redirects after a successful donation

Note that we'll need to test the redirects in our demo environment -- we need to verify that the host in our configuration is the one that users should see. If not, we'll need to rewrite this.
