### PR TITLE
When POSTing to the success/failure pages, user should get redirected

### DIFF
--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -246,3 +246,16 @@ class DonatePagesTests(TestCase):
         response = self.client.get(
             reverse('campaign failure', kwargs={'slug': 'education'}))
         self.assertEqual(response.status_code, 200)
+
+    def test_post_redirect(self):
+        """All POSTs to the project/campaign success/failure pages should get
+        redirected to the same page as a GET"""
+        for proj_camp, slug in (('project', 'local-ultrasound-machine'),
+                                ('campaign', 'education')):
+            for succ_fail in ('success', 'failure'):
+                url = reverse(proj_camp + ' ' + succ_fail,
+                              kwargs={'slug': slug})
+                response = self.client.post(
+                    url, data={'agency_tracking_id': 'NEVERUSED'})
+                self.assertEqual(response.status_code, 302)
+                self.assertTrue(url in response['LOCATION'])

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -224,6 +224,12 @@ class ProjectReturn(DetailView):
         'account', 'country', 'featured_image', 'overflow',
         'volunteerpicture')
 
+    def post(self, request, *args, **kwargs):
+        return HttpResponseRedirect(request.path)
+
 
 class CampaignReturn(DetailView):
     queryset = Campaign.objects.select_related('account', 'featured_image')
+
+    def post(self, request, *args, **kwargs):
+        return HttpResponseRedirect(request.path)


### PR DESCRIPTION
Pay.gov redirects the user to our site with a POST. Redirect the user to the same success/failure page as a GET (since the tracking id said POST carries is no longer useful)
