### PR TITLE
Added CircleCI Config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+    python:
+        version: 3.4.1
+
+general:
+    build_dir: peacecorps
+
+dependencies:
+    pre:
+        - pip install -r requirements.txt 
+        - pip install -r requirements-dev.txt
+
+test:
+    override:
+        - python manage.py test --settings=peacecorps.settings.test


### PR DESCRIPTION
18F is moving away from Travis in favor of another CI provider. This PR adds support for CircleCI instead.
