### PR TITLE
More thorough password checks

### DIFF
--- a/peacecorps/contenteditor/admin.py
+++ b/peacecorps/contenteditor/admin.py
@@ -2,18 +2,13 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
 
-from .form import (
+from .forms import (
     StrictAdminPasswordChangeForm, StrictUserCreationForm)
-from .models import Editor
 
 
 class StrictUserAdmin(UserAdmin):
     add_form = StrictUserCreationForm
     change_password_form = StrictAdminPasswordChangeForm
-
-    def __init__(self, *args, **kwargs):
-        super(StrictUserAdmin, self).__init__(*args, **kwargs)
-        self.model = Editor
 
 
 admin.site.unregister(User)

--- a/peacecorps/contenteditor/admin.py
+++ b/peacecorps/contenteditor/admin.py
@@ -4,11 +4,17 @@ from django.contrib.auth.models import User
 
 from .form import (
     StrictAdminPasswordChangeForm, StrictUserCreationForm)
+from .models import Editor
 
 
 class StrictUserAdmin(UserAdmin):
     add_form = StrictUserCreationForm
     change_password_form = StrictAdminPasswordChangeForm
+
+    def __init__(self, *args, **kwargs):
+        super(StrictUserAdmin, self).__init__(*args, **kwargs)
+        self.model = Editor
+
 
 admin.site.unregister(User)
 admin.site.register(User, StrictUserAdmin)

--- a/peacecorps/contenteditor/backends.py
+++ b/peacecorps/contenteditor/backends.py
@@ -1,0 +1,12 @@
+from django.contrib.auth import backends
+from .models import Editor
+
+
+class EditorBackend(backends.ModelBackend):
+    """Always return an Editor rather than a generic User"""
+
+    def get_user(self, user_id):
+        try:
+            return Editor.objects.get(pk=user_id)
+        except Editor.DoesNotExist:
+            return None

--- a/peacecorps/contenteditor/form.py
+++ b/peacecorps/contenteditor/form.py
@@ -6,33 +6,6 @@ from django.utils.translation import ugettext_lazy as _
 from contenteditor import models
 
 
-# Password length requirements
-def password_validator(password):
-    """Validates a given string against required password params. This is
-    required in order to maintain FISMA compliance."""
-    # Set up an errors array to capture things we find
-    errors = []
-
-    # Defines special characters we allow
-    # TODO: I guess this could be a regex instead, I just typed all the chars
-    # on my keyboard :)
-    valid_special_chars = set('~`!@#$%^&*()-_=+[{]}\|;:'",<.>/?/*-.+")
-    if not password:
-        errors.append('Password cannot be blank.')
-    if not any(x.isupper() for x in password):
-        errors.append('Password needs at least one uppercase letter.')
-    if not any(x.islower() for x in password):
-        errors.append('Password needs at least one lowercase letter.')
-    if not any(x.isdigit() for x in password):
-        errors.append('Password needs at least one number.')
-    if not any((x in valid_special_chars) for x in password):
-        errors.append('Password needs a special character.')
-    if not len(password) >= 20:
-        errors.append('Password must be at least 20 characters in length.')
-
-    return errors
-
-
 class StrictUserCreationForm(UserCreationForm):
     password1 = forms.CharField(
         label=_("Password"), widget=forms.PasswordInput, help_text=_("""
@@ -45,7 +18,7 @@ class StrictUserCreationForm(UserCreationForm):
         """Adds to the default password validation routine in order to enforce
         stronger passwords"""
         password = self.cleaned_data['password1']
-        errors = password_validator(password)
+        errors = models.password_errors(password)
 
         # If password_validator returns errors, raise an error, else proceed.
         if errors:
@@ -66,7 +39,7 @@ class StrictAdminPasswordChangeForm(AdminPasswordChangeForm):
         """Adds to the default password validation routine in order to enforce
         stronger passwords"""
         password = self.cleaned_data['password1']
-        errors = password_validator(password)
+        errors = models.password_errors(password)
         # Also check that this is a new password
         if self.user.check_password(self.cleaned_data['password1']):
             errors.append("Must not reuse a password")

--- a/peacecorps/contenteditor/forms.py
+++ b/peacecorps/contenteditor/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import (
-    UserCreationForm, AdminPasswordChangeForm)
+    AdminPasswordChangeForm, PasswordChangeForm, UserCreationForm)
 from django.utils.translation import ugettext_lazy as _
 
 from contenteditor import models
@@ -28,6 +28,7 @@ class StrictUserCreationForm(UserCreationForm):
 
 
 class StrictAdminPasswordChangeForm(AdminPasswordChangeForm):
+    """Password form for editing a user"""
     password1 = forms.CharField(
         label=_("Password"), widget=forms.PasswordInput, help_text=_("""
             Enter a password. Requirements include: at least 20 characters,
@@ -52,6 +53,37 @@ class StrictAdminPasswordChangeForm(AdminPasswordChangeForm):
 
     def save(self):
         user = super(StrictAdminPasswordChangeForm, self).save()
+        user.extra.password_expires = models.expires()
+        user.extra.save()
+        return user
+
+
+class StrictPasswordChangeForm(PasswordChangeForm):
+    """Password form residing at /admin/password_change"""
+    new_password1 = forms.CharField(
+        label=_("New password"), widget=forms.PasswordInput, help_text=_("""
+            Enter a password. Requirements include: at least 20 characters,
+            at least one uppercase letter, at least one lowercase letter, at
+            least one number, and at least one special character.
+            """))
+
+    def clean_new_password1(self):
+        """Adds to the default password validation routine in order to enforce
+        stronger passwords"""
+        password = self.cleaned_data['new_password1']
+        errors = models.password_errors(password)
+        # Also check that this is a new password
+        if self.user.check_password(self.cleaned_data['new_password1']):
+            errors.append("Must not reuse a password")
+
+        # If password_validator returns errors, raise an error, else proceed.
+        if errors:
+            raise forms.ValidationError('\n'.join(errors))
+        else:
+            return password
+
+    def save(self):
+        user = super(StrictPasswordChangeForm, self).save()
         user.extra.password_expires = models.expires()
         user.extra.save()
         return user

--- a/peacecorps/contenteditor/migrations/0002_editor.py
+++ b/peacecorps/contenteditor/migrations/0002_editor.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+        ('contenteditor', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Editor',
+            fields=[
+            ],
+            options={
+                'proxy': True,
+            },
+            bases=('auth.user',),
+        ),
+    ]

--- a/peacecorps/contenteditor/models.py
+++ b/peacecorps/contenteditor/models.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.db import models
 from django.utils import timezone
 from django.db.models.signals import post_save
@@ -27,3 +28,44 @@ def connect_user(sender, instance, created, *args, **kwargs):
         ExtraUserFields.objects.create(user=instance)
 
 post_save.connect(connect_user, sender=settings.AUTH_USER_MODEL)
+
+
+class Editor(User):
+    """Content editors (synonymous with user in our application) has specific
+    requirements for setting user passwords."""
+    class Meta:
+        proxy = True
+
+    def set_password(self, raw_password):
+        """We add special password validation checks here"""
+        errors = password_errors(raw_password)
+        if errors:
+            raise ValueError(" ".join(errors))
+        return super(Editor, self).set_password(raw_password)
+
+
+def password_errors(password):
+    """Validates a given string against required password params. This is
+    required in order to maintain FISMA compliance."""
+    # Set up an errors array to capture things we find
+    errors = []
+    password = password or ""   # account for Nones
+
+    # Defines special characters we allow
+    # TODO: I guess this could be a regex instead, I just typed all the
+    # chars on my keyboard :)
+    valid_special_chars = set('~`!@#$%^&*()-_=+[{]}\|;:'",<.>/?/*-.+")
+    if not password:
+        errors.append('Password cannot be blank.')
+    if not any(x.isupper() for x in password):
+        errors.append('Password needs at least one uppercase letter.')
+    if not any(x.islower() for x in password):
+        errors.append('Password needs at least one lowercase letter.')
+    if not any(x.isdigit() for x in password):
+        errors.append('Password needs at least one number.')
+    if not any((x in valid_special_chars) for x in password):
+        errors.append('Password needs a special character.')
+    if not len(password) >= 20:
+        errors.append('Password must be at least 20 characters in length.')
+
+    return errors

--- a/peacecorps/contenteditor/models.py
+++ b/peacecorps/contenteditor/models.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 from django.db.models.signals import post_save
@@ -40,7 +41,7 @@ class Editor(User):
         """We add special password validation checks here"""
         errors = password_errors(raw_password)
         if errors:
-            raise ValueError(" ".join(errors))
+            raise ValidationError(" ".join(errors))
         return super(Editor, self).set_password(raw_password)
 
 

--- a/peacecorps/contenteditor/tests/test_backends.py
+++ b/peacecorps/contenteditor/tests/test_backends.py
@@ -1,0 +1,19 @@
+from django.contrib.auth import get_user
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from django.test import Client, TestCase
+
+from contenteditor.models import Editor
+
+
+class BackendEditorTests(TestCase):
+    def test_request_user(self):
+        """Verify that the request user is an 'Editor' """
+        user = User.objects.create_user('tim', password='tim')
+        client = Client()
+        client.login(username=user.username, password=user.username)
+        request = HttpRequest()
+        request.session = client.session
+        user = get_user(request)
+        self.assertTrue(isinstance(user, Editor))
+        user.delete()

--- a/peacecorps/contenteditor/tests/test_models.py
+++ b/peacecorps/contenteditor/tests/test_models.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from contenteditor import models
@@ -6,7 +6,44 @@ from contenteditor import models
 
 class ExtraUserTests(TestCase):
     def test_creation(self):
-        user = User.objects.create_user('bob', password='bob')
+        user = get_user_model().objects.create_user('bob', password='bob')
         self.assertNotEqual(None, user.extra.password_expires)
         user.delete()
         self.assertEqual(0, len(models.ExtraUserFields.objects.all()))
+
+
+class EditorTests(TestCase):
+    def test_blank(self):
+        """ Check to ensure the password cannot be blank."""
+        self.assertRaises(ValueError, models.Editor.objects.create_user,
+                          {'username': 'testuser', 'password': ''})
+
+    def test_uppercase(self):
+        """ Check to ensure the password contains an uppercase letter."""
+        self.assertRaises(ValueError, models.Editor.objects.create_user,
+                          {'username': 'testuser',
+                           'password': 'q*9x=^2hg&v7u?u9tg?u'})
+
+    def test_lowercase(self):
+        """ Check to ensure the password contains a lowercase letter."""
+        self.assertRaises(ValueError, models.Editor.objects.create_user,
+                          {'username': 'testuser',
+                           'password': 'A=R7-%=K?K@B^!9Q8=C+'})
+
+    def test_number(self):
+        """ Check to ensure the password contains a number."""
+        self.assertRaises(ValueError, models.Editor.objects.create_user,
+                          {'username': 'testuser',
+                           'password': 'CDr=cpz&Z&a!cuP-nAQe'})
+
+    def test_specialchar(self):
+        """ Check to ensure the password contains a special character."""
+        self.assertRaises(ValueError, models.Editor.objects.create_user,
+                          {'username': 'testuser',
+                           'password': 'vNzwXpzKJyTshvHsuULn'})
+
+    def test_length(self):
+        """ Check to ensure the password is 20 characters long."""
+        self.assertRaises(ValueError, models.Editor.objects.create_user,
+                          {'username': 'testuser',
+                           'password': 'c897B$eH@'})

--- a/peacecorps/contenteditor/tests/test_models.py
+++ b/peacecorps/contenteditor/tests/test_models.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from contenteditor import models
@@ -15,35 +16,35 @@ class ExtraUserTests(TestCase):
 class EditorTests(TestCase):
     def test_blank(self):
         """ Check to ensure the password cannot be blank."""
-        self.assertRaises(ValueError, models.Editor.objects.create_user,
+        self.assertRaises(ValidationError, models.Editor.objects.create_user,
                           {'username': 'testuser', 'password': ''})
 
     def test_uppercase(self):
         """ Check to ensure the password contains an uppercase letter."""
-        self.assertRaises(ValueError, models.Editor.objects.create_user,
+        self.assertRaises(ValidationError, models.Editor.objects.create_user,
                           {'username': 'testuser',
                            'password': 'q*9x=^2hg&v7u?u9tg?u'})
 
     def test_lowercase(self):
         """ Check to ensure the password contains a lowercase letter."""
-        self.assertRaises(ValueError, models.Editor.objects.create_user,
+        self.assertRaises(ValidationError, models.Editor.objects.create_user,
                           {'username': 'testuser',
                            'password': 'A=R7-%=K?K@B^!9Q8=C+'})
 
     def test_number(self):
         """ Check to ensure the password contains a number."""
-        self.assertRaises(ValueError, models.Editor.objects.create_user,
+        self.assertRaises(ValidationError, models.Editor.objects.create_user,
                           {'username': 'testuser',
                            'password': 'CDr=cpz&Z&a!cuP-nAQe'})
 
     def test_specialchar(self):
         """ Check to ensure the password contains a special character."""
-        self.assertRaises(ValueError, models.Editor.objects.create_user,
+        self.assertRaises(ValidationError, models.Editor.objects.create_user,
                           {'username': 'testuser',
                            'password': 'vNzwXpzKJyTshvHsuULn'})
 
     def test_length(self):
         """ Check to ensure the password is 20 characters long."""
-        self.assertRaises(ValueError, models.Editor.objects.create_user,
+        self.assertRaises(ValidationError, models.Editor.objects.create_user,
                           {'username': 'testuser',
                            'password': 'c897B$eH@'})

--- a/peacecorps/contenteditor/tests/test_urls.py
+++ b/peacecorps/contenteditor/tests/test_urls.py
@@ -41,3 +41,30 @@ class ExpirationTests(TestCase):
                          password=self.user.username)
             resp = client.get('/admin/')
             self.assertEqual(resp.status_code, 200)
+
+
+class PasswordChangeTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('joe', password='joe')
+        self.user.is_staff = True
+        self.user.save()
+
+    def tearDown(self):
+        self.user.delete()
+
+    def test_extra_checks(self):
+        """Verify that the password change page checks our extra
+        requirements"""
+        client = Client()
+        client.login(username=self.user.username, password=self.user.username)
+        resp = client.post('/admin/password_change/',
+                           data={'old_password': self.user.username,
+                                 'new_password1': 'q*9x=^2hg&v7u?u9tg?u',
+                                 'new_password2': 'q*9x=^2hg&v7u?u9tg?u'})
+        self.assertContains(resp, 'errorlist')
+        # Add an uppercase letter
+        resp = client.post('/admin/password_change/',
+                           data={'old_password': self.user.username,
+                                 'new_password1': 'q*9x=^2Hg&v7u?u9tg?u',
+                                 'new_password2': 'q*9x=^2Hg&v7u?u9tg?u'})
+        self.assertEqual(resp.status_code, 302)

--- a/peacecorps/contenteditor/tests/test_urls.py
+++ b/peacecorps/contenteditor/tests/test_urls.py
@@ -27,8 +27,7 @@ class ExpirationTests(TestCase):
         client.login(username=self.user.username, password=self.user.username)
         resp = client.get('/admin/')
         self.assertEqual(resp.status_code, 302)
-        url = '/admin/auth/user/%d/password/' % self.user.id
-        self.assertTrue(url in resp['LOCATION'])
+        self.assertTrue('/admin/password_change/' in resp['LOCATION'])
 
     def test_access_whitelist(self):
         """If a password has expired, certain pages in a whitelist are still

--- a/peacecorps/contenteditor/urls.py
+++ b/peacecorps/contenteditor/urls.py
@@ -1,5 +1,6 @@
 from django.apps import apps
-from django.core.urlresolvers import RegexURLPattern, RegexURLResolver
+from django.core.urlresolvers import (
+    RegexURLPattern, RegexURLResolver, reverse)
 from django.conf import settings
 from django.conf.urls import patterns, url
 from django.http import HttpResponseRedirect
@@ -11,18 +12,14 @@ from .forms import StrictPasswordChangeForm
 def _wrap(callback):
     """Wrap an url callback with a test for password expiration"""
     def inner(request, *args, **kwargs):
+        pass_change_url = reverse('admin:password_change')
         if (request.path in settings.PASSWORD_EXPIRATION_WHITELIST
                 or (not request.user.is_authenticated())    # deferring
-                or (request.path ==
-                    '/admin/auth/user/%d/password/' % request.user.id)
+                or (request.path == pass_change_url)
                 or (request.user.extra.password_expires > timezone.now())):
             return callback(request, *args, **kwargs)
         else:   # Password expired and not in whitelist
-            # @todo: it makes more sense to not hard-code this, but we need to
-            # change password validation first
-            return HttpResponseRedirect(
-                '/admin/auth/user/%d/password/' % request.user.id)
-            # return HttpResponseRedirect(reverse('admin:password_change'))
+            return HttpResponseRedirect(pass_change_url)
     return inner
 
 

--- a/peacecorps/contenteditor/urls.py
+++ b/peacecorps/contenteditor/urls.py
@@ -5,6 +5,8 @@ from django.conf.urls import patterns, url
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 
+from .forms import StrictPasswordChangeForm
+
 
 def _wrap(callback):
     """Wrap an url callback with a test for password expiration"""
@@ -39,6 +41,15 @@ if apps.is_installed('django.contrib.admin'):
     from django.contrib import admin
     altered = [_wrap_patterns(u) for u in admin.site.get_urls()]
     urlpatterns = patterns(
-        '', url('', (altered, 'admin', 'admin')))
+        '',
+        #   Override this url, which would appear later in the list
+        url(r'^password_change/$',
+            'django.contrib.auth.views.password_change',
+            {'password_change_form': StrictPasswordChangeForm},
+            name='password_change'),
+        url(r'^password_change/done/$',
+            'django.contrib.auth.views.password_change_done',
+            name='password_change_done'),
+        url('', (altered, 'admin', 'admin')))
 else:
     urlpatterns = []

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -94,4 +94,3 @@ PASSWORD_EXPIRATION_WHITELIST = [
 ]
 
 AUTHENTICATION_BACKENDS = ('contenteditor.backends.EditorBackend',)
-#AUTH_USER_MODEL = 'contenteditor.Editor'

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -92,3 +92,6 @@ PASSWORD_EXPIRATION_WHITELIST = [
     '/admin/logout/',
     '/admin/jsi18n/'
 ]
+
+AUTHENTICATION_BACKENDS = ('contenteditor.backends.EditorBackend',)
+#AUTH_USER_MODEL = 'contenteditor.Editor'


### PR DESCRIPTION
Prior to this, the password checks could be circumvented by using the `/admin/password_change/` url. This pull request closes that loop hole, but also tried to create a more permanent solution.
- Add a proxy model, `Editor`, which will throw a validation error when trying to set a password that doesn't meet our requirements. This error occurs very late in the game, though, so would generally result in a 500. It should be thought of as a final safety
- Add a authentication "backend", which makes sure to return `Editor` objects instead of `User`s
- Replace the password change form with an extended form for checking the password requirements. Previously, we had only replaced the password setting form in the `Users` admin
- When a user's password has expired, redirect them to `/admin/password_change/` instead of the `Users` admin page, as this requires fewer permissions
- Duplicate and consolidate tests to review the above
