### PR TITLE
Fixed directory to install python requirements from

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,8 @@ general:
 
 dependencies:
     pre:
-        - pip install -r requirements.txt 
-        - pip install -r requirements-dev.txt
+        - pip install -r ../requirements.txt 
+        - pip install -r ../requirements-dev.txt
 
 test:
     override:


### PR DESCRIPTION
I neglected to commit a small fix that needs to happen for Circle to correctly install dependencies. This will fix that. Also, here's a passing build... 1:20 in duration! https://circleci.com/gh/seanherron/peacecorps-site/1
