### PR TITLE
Account for different amount formats from pay.gov

### DIFF
--- a/peacecorps/paygov/views.py
+++ b/peacecorps/paygov/views.py
@@ -38,7 +38,7 @@ def results(request):
         message = request.POST.get('error_message', 'Unknown error')
     elif not request.POST.get('payment_amount'):
         message = 'Missing payment_amount'
-    elif not re.match(r'^\d+\.\d{2}$', request.POST.get('payment_amount')):
+    elif not re.match(r'^\d+(\.\d*)?$', request.POST.get('payment_amount')):
         message = 'Invalid payment_amount'
     else:
         info = DonorInfo.objects.filter(


### PR DESCRIPTION
We received a `payment_amount` from pay.gov with the format

``` python
'payment_amount': '50.0'
```

Expand the accepted amount formats a bit.
