### PR TITLE
Updates to import script

### DIFF
--- a/peacecorps/peacecorps/management/commands/sync_accounting.py
+++ b/peacecorps/peacecorps/management/commands/sync_accounting.py
@@ -52,14 +52,16 @@ def create_account(row, issue_map):
     """This is a new project/campaign. Determine the account type and create
     the appropriate project, country fund, etc."""
     acc_type = account_type(row)
-    account = Account(
-        name=row['PROJ_NAME'], code=row['PROJ_CODE'], category=acc_type)
+    name = row['PROJ_NAME']
+    if Account.objects.filter(name=name).first():
+        name = name + ' (' + row['PROJ_CODE'] + ')'
+    account = Account(name=name, code=row['PROJ_CODE'], category=acc_type)
     if acc_type == Account.PROJECT:
         create_pcpp(account, row, issue_map)
     else:   # Campaign
         account.save()
         campaign = Campaign.objects.create(
-            name=row['PROJ_NAME'], account=account, campaigntype=acc_type,
+            name=name, account=account, campaigntype=acc_type,
             description=row['SUMMARY'])
         if acc_type == Account.SECTOR:
             # Make sure we remember the sector this is marked as

--- a/peacecorps/peacecorps/migrations/0031_sectormapping.py
+++ b/peacecorps/peacecorps/migrations/0031_sectormapping.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0030_auto_20141103_1918'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SectorMapping',
+            fields=[
+                ('accounting_name', models.CharField(max_length=50, serialize=False, primary_key=True)),
+                ('campaign', models.ForeignKey(to='peacecorps.Campaign')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -2,8 +2,9 @@ from datetime import timedelta
 
 from django.conf import settings
 from django.db import models
-from django.utils import timezone
 from django.db.models import Sum
+from django.utils import timezone
+from django.utils.text import slugify
 from localflavor.us.models import USPostalCodeField
 from tinymce import models as tinymce_models
 
@@ -123,7 +124,19 @@ class Campaign(models.Model):
     def __str__(self):
         return self.name
 
-    # TODO: slugify in admin, override save to preserve unique on general?
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            self.slug = slugify(self.name)
+        super(Campaign, self).save(*args, **kwargs)
+
+
+class SectorMapping(models.Model):
+    """When importing data from the accounting software, a 'sector' field
+    indicates how individual projects should be categorized. The text used in
+    this field does not directly match anything we store, however, so we use a
+    mapping object, which is populated on data import."""
+    accounting_name = models.CharField(max_length=50, primary_key=True)
+    campaign = models.ForeignKey(Campaign)
 
 
 class Country(models.Model):

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -242,6 +242,17 @@ class Project(models.Model):
     def __str__(self):
         return self.title
 
+    def save(self, *args, **kwargs):
+        """Set slug, but make sure it is distinct"""
+        if not self.slug:
+            self.slug = slugify(self.title)
+            existing = Project.objects.filter(
+                # has some false positives, but almost no false negatives
+                slug__startswith=self.slug).order_by('-pk').first()
+            if existing:
+                self.slug = self.slug + str(existing.pk)
+        super(Project, self).save(*args, **kwargs)
+
 
 def default_expire_time():
     return timezone.now() + timedelta(minutes=settings.DONOR_EXPIRE_AFTER)

--- a/peacecorps/peacecorps/tests/test_models.py
+++ b/peacecorps/peacecorps/tests/test_models.py
@@ -35,9 +35,9 @@ class AccountTest(TestCase):
 
         acc1 = models.Account.objects.create(
             name='Account1', code='112-358', current=150)
-        donation1 = makedonation(acc1, 75)
-        donation2 = makedonation(acc1, 100)
-        donation3 = makedonation(acc1, 1)
+        makedonation(acc1, 75)
+        makedonation(acc1, 100)
+        makedonation(acc1, 1)
 
         self.assertEqual(326, acc1.total())
 
@@ -63,3 +63,17 @@ class ProjectTests(TestCase):
 
         proj.delete()
         account.delete()
+
+    def test_slug_collision(self):
+        """Project slug should be derived from title, yet unique"""
+        account1 = models.Account.objects.create(name='Acc', code='ACC')
+        account2 = models.Account.objects.create(name='Acc2', code='ACC2')
+        country = models.Country.objects.get(name='Mexico')
+        proj1 = models.Project.objects.create(
+            title='Project', country=country, account=account1)
+        proj2 = models.Project.objects.create(
+            title='Project', country=country, account=account2)
+        self.assertEqual(proj1.slug, 'project')
+        self.assertEqual(proj2.slug, 'project1')
+        account1.delete()
+        account2.delete()

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -1,20 +1,20 @@
 from datetime import datetime
 import tempfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 from django.utils import timezone
 
-from peacecorps.management.commands.sync_accounting import (
-    cents_from, Command, create_account_pcpp, datetime_from, update_account)
-from peacecorps.models import Account, Donation, Project
+from peacecorps.management.commands import sync_accounting as sync
+from peacecorps.models import (
+    Account, Campaign, Donation, Project, SectorMapping)
 
 
 class SyncAccountingTests(TestCase):
     fixtures = ['tests.yaml']
 
     def test_datetime_from(self):
-        dt = datetime_from('2012-03-20 16:45:01')
+        dt = sync.datetime_from('2012-03-20 16:45:01')
         self.assertEqual(2012, dt.year)
         self.assertEqual(3, dt.month)
         self.assertEqual(20, dt.day)
@@ -23,9 +23,9 @@ class SyncAccountingTests(TestCase):
         self.assertEqual(1, dt.second)
 
     def test_cents_from(self):
-        self.assertEqual(123456789, cents_from('1,234,567.89'))
-        self.assertEqual(12300, cents_from('123'))
-        self.assertRaises(ValueError, cents_from, '12.34.56')
+        self.assertEqual(123456789, sync.cents_from('1,234,567.89'))
+        self.assertEqual(12300, sync.cents_from('123'))
+        self.assertRaises(ValueError, sync.cents_from, '12.34.56')
 
     def test_update_account(self):
         """Use fake data to verify that amount fields are updated and old
@@ -44,7 +44,7 @@ class SyncAccountingTests(TestCase):
 
         row = {'LAST_UPDATED_FROM_PAYGOV': '2009-12-14 15:16:17',
                'REVENUE': '1,234.23'}
-        update_account(row, acc222)
+        sync.update_account(row, acc222)
         # before_donation should be deleted, but after_donation not
         self.assertEqual(
             None, Donation.objects.filter(pk=before_donation.pk).first())
@@ -54,14 +54,18 @@ class SyncAccountingTests(TestCase):
         # amount donated to should also be updated
         self.assertEqual(123423, Account.objects.get(pk=acc222.pk).current)
 
-    def test_create_account_pcpp(self):
-        """Use fake data to generate a new account and pcpp"""
+    def test_create_pcpp(self):
+        """Use fake data to generate a new pcpp"""
+        account = Account(name='New Project Effort', code='098-765',
+                          category=Account.PROJECT)
         row = {
-            'PROJ_CODE': '098-765', 'COUNTY_NAME': 'CHINA',
+            'PROJ_CODE': '098-765', 'COUNTRY_NAME': 'CHINA',
             'PROJ_NAME': 'New Project Effort', 'PCV_NAME': 'IN Jones, B.',
             'STATE': 'IN', 'COMM_CONTRIB': '1234.56', 'PROJ_REQUEST': '3,434',
             'PROJ_BAL': '1,111', 'SECTOR': 'IT', 'SUMMARY': 'sum sum sum'}
-        create_account_pcpp(row)
+        issue_cache = Mock()
+        issue_cache.find.return_value = Campaign.objects.get(name='Technology')
+        sync.create_pcpp(account, row, issue_cache)
         project = Project.objects.get(title='New Project Effort')
         self.assertEqual(project.account.code, '098-765')
         self.assertEqual(project.country.name, 'China')
@@ -74,10 +78,50 @@ class SyncAccountingTests(TestCase):
         self.assertEqual(project.campaigns.all()[0].name, 'Technology')
         self.assertEqual(project.description, 'sum sum sum')
         self.assertFalse(project.published)
+        project.delete()
+        account.delete()
+
+    @patch('peacecorps.management.commands.sync_accounting.create_pcpp')
+    def test_create_account_project(self, create):
+        """Test that execution is deferred to the create_pcpp method"""
+        row = {'PROJ_NAME': 'Some Proj', 'PROJ_CODE': '121-212',
+               'SECTOR': 'IT'}
+        sync.create_account(row, None)
+        self.assertTrue(create.called)
+        account, row, issue_map = create.call_args[0]
+        self.assertEqual(account.name, 'Some Proj')
+        self.assertEqual(account.code, '121-212')
+        self.assertEqual(account.category, Account.PROJECT)
+        self.assertIsNone(account.pk)
+
+    def test_create_account_campaign(self):
+        """Campaigns should be created"""
+        row = {'PROJ_NAME': 'Argentina Fund', 'PROJ_CODE': '789-CFD',
+               'SUMMARY': 'Some Sum'}
+        sync.create_account(row, None)
+        account = Account.objects.get(code='789-CFD')
+        campaign = Campaign.objects.get(account=account)
+        self.assertEqual(campaign.name, 'Argentina Fund')
+        self.assertEqual(campaign.account, account)
+        self.assertEqual(campaign.description, 'Some Sum')
+        self.assertEqual(campaign.slug, 'argentina-fund')
+        account.delete()    # cascades
+
+    def test_create_account_sector(self):
+        """The creation of sectors creates a sector map, too"""
+        row = {'PROJ_NAME': 'Renewal Fund', 'PROJ_CODE': 'SPF-REN',
+               'COUNTRY_NAME': 'D/OSP/GGM', 'SUMMARY': 'Some Sum',
+               'SECTOR': 'RENEW'}
+        sync.create_account(row, None)
+        account = Account.objects.get(code='SPF-REN')
+        campaign = Campaign.objects.get(account=account)
+        mapping = SectorMapping.objects.get(pk='RENEW')
+        self.assertEqual(mapping.campaign, campaign)
+        account.delete()    # cascades
 
     @patch('peacecorps.management.commands.sync_accounting.update_account')
     @patch('peacecorps.management.commands.sync_accounting.'
-           + 'create_account_pcpp')
+           + 'create_account')
     def test_command(self, create, update):
         """Verify CSV reading and that the update/create are called"""
         filedata = "PROJ_CODE,OTHER_FIELD,LAST_UPDATED_FROM_PAYGOV,REVENUE\n"
@@ -92,10 +136,54 @@ class SyncAccountingTests(TestCase):
         account456 = Account.objects.create(name='account1', code='123-456')
         account222 = Account.objects.create(name='account2', code='111-222')
 
-        command = Command()
+        command = sync.Command()
         command.handle(csv_path)
 
         self.assertEqual(create.call_count, 1)
         self.assertEqual(update.call_count, 2)
         account222.delete()
         account456.delete()
+
+    def test_account_type_country(self):
+        row = {'PROJ_CODE': '123-CFD'}
+        self.assertEqual(Account.COUNTRY, sync.account_type(row))
+        row = {'PROJ_CODE': '111-222', 'SECTOR': 'None', 'PROJ_REQUEST': '0',
+               'COUNTRY_NAME': 'RUSSIA', 'PCV_NAME': 'RUSSIA COUNTRY FUND'}
+        self.assertEqual(Account.COUNTRY, sync.account_type(row))
+
+    def test_account_type_memorial(self):
+        row = {'PROJ_CODE': 'SPF-BOB', 'SECTOR': 'None', 'PROJ_REQUEST': '0',
+               'COUNTRY_NAME': 'MOZAMBIQUE',
+               'PROJ_NAME': 'Bob Jones Memorial Fund',
+               'PCV_NAME': 'BOB JONES MEMORIAL FUND'}
+        self.assertEqual(Account.MEMORIAL, sync.account_type(row))
+
+    def test_account_type_sector(self):
+        row = {'PROJ_CODE': 'SPF-YTH', 'SECTOR': 'Youth Development',
+               'PROJ_REQUEST': '2550', 'COUNTRY_NAME': 'D/OSP/GGM',
+               'PROJ_NAME': 'Youth Fund', 'PCV_NAME': 'The Youth Fund'}
+        self.assertEqual(Account.SECTOR, sync.account_type(row))
+        row = {'PROJ_CODE': 'SPF-YTH', 'SECTOR': 'Youth Development',
+               'PROJ_REQUEST': '2550', 'COUNTRY_NAME': '',
+               'PROJ_NAME': 'Youth Fund', 'PCV_NAME': 'YOUTH FUND'}
+        self.assertEqual(Account.SECTOR, sync.account_type(row))
+
+    def test_account_type_project(self):
+        row = {'PROJ_CODE': '123-456', 'SECTOR': 'IT', 'PROJ_REQUEST': '0',
+               'COUNTRY_NAME': 'FRANCE', 'PROJ_NAME': 'Proj Proj',
+               'PCV_NAME': 'B. Smith', 'COMM_CONTRIB': ''}
+        self.assertEqual(Account.PROJECT, sync.account_type(row))
+        row = {'PROJ_CODE': '123-456-A', 'SECTOR': 'IT', 'PROJ_REQUEST': '0',
+               'COUNTRY_NAME': 'FRANCE', 'PROJ_NAME': 'Proj Proj',
+               'PCV_NAME': 'B. Smith', 'COMM_CONTRIB': '123.45'}
+        self.assertEqual(Account.PROJECT, sync.account_type(row))
+        row = {'PROJ_CODE': '123-456-A', 'SECTOR': 'IT', 'PROJ_REQUEST': '150',
+               'COUNTRY_NAME': 'FRANCE', 'PROJ_NAME': 'Proj Proj',
+               'PCV_NAME': 'B. Smith', 'COMM_CONTRIB': ''}
+        self.assertEqual(Account.PROJECT, sync.account_type(row))
+
+    def test_account_type_general(self):
+        row = {'PROJ_CODE': 'PCF-GEN', 'SECTOR': 'None', 'PROJ_REQUEST': '0',
+               'COUNTRY_NAME': 'D/OSP/GGM', 'PROJ_NAME': 'General Fund',
+               'PCV_NAME': 'General Fund', 'COMM_CONTRIB': ''}
+        self.assertEqual(Account.OTHER, sync.account_type(row))


### PR DESCRIPTION
Now that we've seen an example data file, the import script has been updated to account for issues found. I apologize for the size of the pull request -- it accounts for a lot of small issues.
- For the time being, accept datetimes in `%d-%b-%y` until the data can be cleaned up
- Previously, we had a manual mapping of "sector" values to campaign names. This takes a different strategy; whenever a sector fund is imported, an entry is added to the SectorMapping table. Determining the campaign associated with a given project using the "sector" field, then, is simply a lookup in that table
- `create_account_pcpp` has been split into a function for creating the account and campaign and a function for creation the project. Previously, we assumed that the list would only contain projects, so the logic needed to be altered to accommodate country, memorial, sector, and general funds.
- Added code to account for non-unique account names (the fund code is concatenated)
- Added code to account for non-unique project slugs (an integer is tacked on)
- Campaigns and Projects now automatically set their slug when saving.
- Multiple expected field names (as seen in the CSV) have been updated
- Description/summary is now imported
- The CSV does not include the current fund amount, but does include the fund's goal and "balance", so the logic is now a subtraction
- Determine if we're creating a project, country fund, memorial fund, etc. through heuristics (which match the provided data). See `account_type()`
- Assume a non-utf8 encoding to the import file
