### PR TITLE
Jshint, callback immediately, 60 seconds

### DIFF
--- a/peacecorps/peacecorps/static/peacecorps/js/.jshintrc
+++ b/peacecorps/peacecorps/static/peacecorps/js/.jshintrc
@@ -14,8 +14,7 @@
   "strict": true,
   "undef": false,
   "unused": true,
-  "validthis": true
-
+  "validthis": true,
   "boss": true,
   "browser": true,
   "globalstrict": true,
@@ -23,6 +22,7 @@
   "globals": {
     "$": true,
     "_": true,
-    "PC": true
+    "PC": true,
+    "jQuery": true
   }
 }

--- a/peacecorps/peacecorps/static/peacecorps/js/update_donatepercent.js
+++ b/peacecorps/peacecorps/static/peacecorps/js/update_donatepercent.js
@@ -1,9 +1,9 @@
 /* Update donations percentages on project pages. */
+'use strict';
 
 var PC = PC || {};
 
 (function($) {
-  'use strict';
 
   PC.UpdatePercent = function(root){
     this.$root = root;
@@ -15,11 +15,11 @@ var PC = PC || {};
     }).done(this.updateHTML.bind(this));
   };
   PC.UpdatePercent.prototype.getCode = function(){
-    this.code = this.$root.data("project-code");
+    this.code = this.$root.data('project-code');
   };
   PC.UpdatePercent.prototype.updateHTML = function(oData){
-    var bar = this.$root.find(".funded-amount-bar");
-    var text = this.$root.find(".funded-amount-text");
+    var bar = this.$root.find('.funded-amount-bar');
+    var text = this.$root.find('.funded-amount-text');
     bar.css('max-width', oData.percent+'%');
     text.text(parseInt(
               Math.round(oData.percent), 10) + '% funded');
@@ -27,7 +27,8 @@ var PC = PC || {};
 
   PC.UpdatePercent.prototype.init = function(){
     this.getCode();
-    var seconds = 5;
+    this.getTotal();  //  rendered data may be out of date
+    var seconds = 60;
     this.interval = setInterval(this.getTotal.bind(this), seconds * 1000);
   };
 


### PR DESCRIPTION
- JSHint fixes
- Make the callback immediately, in case the user is seeing a cached page
- Change from updating every 5 seconds to every 60
