### PR TITLE
Some logging events

### DIFF
--- a/peacecorps/paygov/tests/test_views.py
+++ b/peacecorps/paygov/tests/test_views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
@@ -79,7 +81,7 @@ class ResultsTests(TestCase):
         delete the associated donorinfo and log accordingly"""
         data = {'agency_tracking_id': 'TRACK', 'payment_status': 'Canceled',
                 'payment_amount': '125.00', 'error_message': 'ABCDEFG'}
-        with self.assertLogs('paygov.results') as logger:
+        with self.assertLogs('paygov.results', level=logging.WARN) as logger:
             result = self.client.post(reverse('paygov:results'), data=data)
             self.assertContains(result, 'ABCDEFG')
         self.assertEqual(

--- a/peacecorps/paygov/views.py
+++ b/peacecorps/paygov/views.py
@@ -40,7 +40,7 @@ def results(request):
     # Transaction was canceled or had another error
     elif request.POST.get('payment_status') != 'Completed':
         message = request.POST.get('error_message', 'Unknown error')
-        logger.info("Transaction %s: %s", request.POST.get('payment_status'),
+        logger.warn("Transaction %s: %s", request.POST.get('payment_status'),
                     message)
         info.delete()
     elif not request.POST.get('payment_amount'):

--- a/peacecorps/paygov/views.py
+++ b/peacecorps/paygov/views.py
@@ -30,27 +30,31 @@ def results(request):
     message = 'OK'
     if request.method != 'POST':
         return HttpResponseNotAllowed(['POST'])
-    if not request.POST.get('agency_tracking_id'):
-        message = 'Missing agency_tracking_id'
+
+    info = DonorInfo.objects.select_related('account').filter(
+        pk=request.POST.get('agency_tracking_id')).first()
+    if not info:
+        message = 'Invalid agency_tracking_id'
     elif not request.POST.get('payment_status'):
         message = 'Missing payment_status'
+    # Transaction was canceled or had another error
     elif request.POST.get('payment_status') != 'Completed':
         message = request.POST.get('error_message', 'Unknown error')
+        logger.info("Transaction %s: %s", request.POST.get('payment_status'),
+                    message)
+        info.delete()
     elif not request.POST.get('payment_amount'):
         message = 'Missing payment_amount'
     elif not re.match(r'^\d+(\.\d*)?$', request.POST.get('payment_amount')):
         message = 'Invalid payment_amount'
+    # Successful transaction
     else:
-        info = DonorInfo.objects.filter(
-            pk=request.POST.get('agency_tracking_id')).first()
-        if not info:
-            message = 'Invalid agency_tracking_id'
-        else:
-            donation = Donation(
-                amount=float(request.POST.get('payment_amount'))*100)
-            donation.account_id = info.account_id
-            donation.save()
-            info.delete()
-            message = 'OK'
+        donation = Donation(
+            amount=int(float(request.POST.get('payment_amount'))*100))
+        donation.account_id = info.account_id
+        donation.save()
+        info.delete()
+        logger.info("Transaction success: %s cents to %s", donation.amount,
+                    info.account.code)
     return HttpResponse('response_message=' + message,
                         content_type='text/plain')

--- a/peacecorps/peacecorps/management/commands/clear_stale_donors.py
+++ b/peacecorps/peacecorps/management/commands/clear_stale_donors.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -8,4 +10,9 @@ class Command(BaseCommand):
     help = "Clear donor info structures that have expired"
 
     def handle(self, *args, **kwargs):
-        DonorInfo.objects.filter(expires_at__lte=timezone.now()).delete()
+        queryset = DonorInfo.objects.filter(expires_at__lte=timezone.now())
+        count = queryset.count()
+        if count:
+            queryset.delete()
+            logging.getLogger('peacecorps.clear_stale_donors').info(
+                "Deleted %s expired donor info objects", count)

--- a/peacecorps/peacecorps/tests/test_clear_state_donors.py
+++ b/peacecorps/peacecorps/tests/test_clear_state_donors.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from peacecorps.management.commands import clear_stale_donors as clear
+from peacecorps.models import Account, DonorInfo
+
+
+class ClearStaleDonorTests(TestCase):
+    def test_handle(self):
+        """Verify that expired donorinfo objects get deleted and that the
+        appropriate logging message is made"""
+        account = Account.objects.create(name='Example', code='EXEXEX')
+        # Create several in the soon-to-be-past
+        for i in range(5):
+            DonorInfo.objects.create(
+                agency_tracking_id=str(i)*5, account=account,
+                expires_at=timezone.now())
+        # Create one in the future
+        DonorInfo.objects.create(
+            agency_tracking_id='future', account=account,
+            expires_at=timezone.now() + timedelta(hours=1))
+        with self.assertLogs('peacecorps.clear_stale_donors') as logger:
+            clear.Command().handle()
+        self.assertEqual(1, account.donorinfos.count())
+        self.assertEqual(1, len(logger.output))
+        self.assertTrue('Deleted 5' in logger.output[0])

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 import tempfile
 from unittest.mock import Mock, patch
 
@@ -122,6 +123,31 @@ class SyncAccountingTests(TestCase):
         self.assertEqual(project.account.current, (343400 - 111100))
         account.delete()    # cascades
 
+    def test_create_pcpp_failure(self):
+        """Country and sector must be valid, lest nothing gets saved. An error
+        should be logged in this situation"""
+        count = Project.objects.count()
+        issue_cache = Mock()
+        issue_cache.find.return_value = Campaign.objects.get(name='Technology')
+        row = {'COUNTRY_NAME': 'NONEXISTENT', 'SECTOR': 'MOCKED'}
+        with self.assertLogs('peacecorps.sync_accounting',
+                             level=logging.WARN) as logger:
+            sync.create_pcpp(None, row, issue_cache)
+        self.assertEqual(count, Project.objects.count())    # nothing created
+        self.assertEqual(1, len(logger.output))
+        self.assertTrue('NONEXISTENT' in logger.output[0])
+        self.assertTrue('MOCKED' in logger.output[0])
+
+        issue_cache.find.return_value = None
+        row = {'COUNTRY_NAME': 'IRELAND', 'SECTOR': 'MOCKED'}
+        with self.assertLogs('peacecorps.sync_accounting',
+                             level=logging.WARN) as logger:
+            sync.create_pcpp(None, row, issue_cache)
+        self.assertEqual(count, Project.objects.count())    # nothing created
+        self.assertEqual(1, len(logger.output))
+        self.assertTrue('IRELAND' in logger.output[0])
+        self.assertTrue('MOCKED' in logger.output[0])
+
     @patch('peacecorps.management.commands.sync_accounting.create_pcpp')
     def test_create_account_project(self, create):
         """Test that execution is deferred to the create_pcpp method"""
@@ -177,14 +203,14 @@ class SyncAccountingTests(TestCase):
         account.delete()    # cascades
 
     @patch('peacecorps.management.commands.sync_accounting.update_account')
-    @patch('peacecorps.management.commands.sync_accounting.'
-           + 'create_account')
-    def test_command(self, create, update):
-        """Verify CSV reading and that the update/create are called"""
-        filedata = "PROJ_CODE,OTHER_FIELD,LAST_UPDATED_FROM_PAYGOV,REVENUE\n"
-        filedata += '123-456,Some Content,2009-12-14 15:16:17,"1,234"\n'
-        filedata += "nonexist,Not Here,2009-12-14 15:16:17,1.23\n"
-        filedata += "111-222,Other Co¿ntent,2009-12-14 15:16:17,1.23\n"
+    @patch('peacecorps.management.commands.sync_accounting.create_account')
+    def test_handle(self, create, update):
+        """Verify CSV reading and that the update/create are called. Also
+        make sure that appropriate logs are created"""
+        filedata = "PROJ_CODE,OTHER_FIELD,PROJ_REQUEST,PROJ_BALANCE\n"
+        filedata += '123-456,Some Content,5555,"1,234"\n'
+        filedata += "nonexist,Not Here,5.00,1.23\n"
+        filedata += "111-222,Other Co¿ntent,5,1.23\n"
         # Note the non-utf character ^
         csv_file_handle, csv_path = tempfile.mkstemp()
         with open(csv_file_handle, 'wb') as csv_file:
@@ -193,8 +219,18 @@ class SyncAccountingTests(TestCase):
         account456 = Account.objects.create(name='account1', code='123-456')
         account222 = Account.objects.create(name='account2', code='111-222')
 
-        command = sync.Command()
-        command.handle(csv_path)
+        with self.assertLogs('peacecorps.sync_accounting') as logger:
+            command = sync.Command()
+            command.handle(csv_path)
+        self.assertEqual(3, len(logger.output))
+        self.assertTrue('123-456' in logger.output[0])
+        self.assertTrue('Updating' in logger.output[0])
+        self.assertTrue('5555' in logger.output[0])
+        self.assertTrue('1,234' in logger.output[0])
+        self.assertTrue('nonexist' in logger.output[1])
+        self.assertTrue('Creating' in logger.output[1])
+        self.assertTrue('111-222' in logger.output[2])
+        self.assertTrue('Updating' in logger.output[2])
 
         self.assertEqual(create.call_count, 1)
         self.assertEqual(update.call_count, 2)

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -8,11 +8,20 @@ from django.utils import timezone
 
 from peacecorps.management.commands import sync_accounting as sync
 from peacecorps.models import (
-    Account, Campaign, Donation, Project, SectorMapping)
+    Account, Campaign, Country, Donation, Project, SectorMapping)
 
 
 class SyncAccountingTests(TestCase):
-    fixtures = ['tests.yaml']
+    def setUp(self):
+        self.campaign_account = Account.objects.create(
+            name='Information Technology', code='SPF-ITC')
+        Campaign.objects.create(
+            name='Technology', account=self.campaign_account)
+        self.china = Country.objects.create(code='CHINA', name='China')
+
+    def tearDown(self):
+        self.campaign_account.delete()  # cascades
+        self.china.delete()
 
     def test_datetime_from(self):
         dt = sync.datetime_from('2012-03-20 16:45:01')


### PR DESCRIPTION
- When pay.gov makes a callback, log the success or failure
- Make sure to delete donor info when above callback is a failure
- When clearing stale donor information, log how many were removed
- When synchronizing account information, log when a new account is added, updated, or a failure occurred (due to invalid country/sector)
- Remove the reliance on the 'tests.yaml' fixture from the synchronization tests. Locally that sped test execution from 35s to 22s
