### PR TITLE
Account for new date format

### DIFF
--- a/peacecorps/peacecorps/management/commands/sync_accounting.py
+++ b/peacecorps/peacecorps/management/commands/sync_accounting.py
@@ -4,22 +4,21 @@ import logging
 import re
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
+import pytz
 
 from peacecorps.models import (
     Account, Campaign, Country, Project, SectorMapping)
 
 
 def datetime_from(text):
-    """Convert a string representation of a datetime into a UTC datetime
-    object."""
-    # This format will no doubt change
-    try:
-        time = datetime.strptime(text, "%Y-%m-%d %H:%M:%S")
-    except ValueError:
-        # Try a different format. @todo: remove once data's cleaned
-        time = datetime.strptime(text, "%d-%b-%y")
-    return timezone.make_aware(time, timezone.get_current_timezone())
+    """Convert a string representation of a date into a UTC datetime. We
+    assume the incoming date is in Eastern and represents the last second of
+    that day"""
+    eastern = pytz.timezone("US/Eastern")
+    time = datetime.strptime(text, "%d-%b-%y")
+    time = time.replace(hour=23, minute=59, second=59)
+    time = eastern.localize(time)
+    return time.astimezone(pytz.utc)
 
 
 def cents_from(text):


### PR DESCRIPTION
Previously, we assumed the CSV would contain full UTC datetime strings. Now we know that the file will contain a single transaction _date_, with the transactions occurring any time on that date. The timezone for said date is eastern.

So, this converts from said format into a UTC datetime representing the last second of the day (in eastern time zone).
