### PR TITLE
Use S3 for hosting of static files

### DIFF
--- a/peacecorps/contenteditor/backends.py
+++ b/peacecorps/contenteditor/backends.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.contrib.auth import backends
 from django.utils.functional import empty, LazyObject
 from django.utils.module_loading import import_string
+# Would it be better to move this requirement elsewhere?
+from storages.backends.s3boto import S3BotoStorage
 
 from .models import Editor
 
@@ -43,3 +45,25 @@ class LoggingStorage(LazyObject):
         result = self.wrapped.delete(name)
         self.logger.info("Deleted file %s", name)
         return result
+
+
+class MediaS3Storage(S3BotoStorage):
+    """Pass through to S3BotoStorage, save that the bucket name is
+    predefined"""
+    def __init__(self, *args, **kwargs):
+        if not args and 'bucket' not in kwargs:
+            super(MediaS3Storage, self).__init__(
+                getattr(settings, 'AWS_MEDIA_BUCKET_NAME', ''), **kwargs)
+        else:
+            super(MediaS3Storage, self).__init__(**kwargs)
+
+
+class StaticS3Storage(S3BotoStorage):
+    """Pass through to S3BotoStorage, save that the bucket name is
+    predefined"""
+    def __init__(self, *args, **kwargs):
+        if not args and 'bucket' not in kwargs:
+            super(StaticS3Storage, self).__init__(
+                getattr(settings, 'AWS_STATIC_BUCKET_NAME', ''), **kwargs)
+        else:
+            super(StaticS3Storage, self).__init__(**kwargs)

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -101,7 +101,7 @@ GPG_RECIPIENTS = {
 
 # Password expire after a set number of days
 PASSWORD_EXPIRE_AFTER = 60   # days
-# Admin paths which can be accessed even when the password has expired
+# Admin paths which can be accessible even when the password has expired
 PASSWORD_EXPIRATION_WHITELIST = [
     '/admin/login/',
     '/admin/logout/',

--- a/peacecorps/peacecorps/settings/production-admin.py
+++ b/peacecorps/peacecorps/settings/production-admin.py
@@ -11,7 +11,7 @@ INSTALLED_APPS += (
 )
 # Only media uploads are logged
 LOGGED_FILE_STORAGE = 'contenteditor.backends.MediaS3Storage'
-# We arsse not using this setting in favor of the two below it
+# We are not using this setting in favor of the two below it
 # AWS_STORAGE_BUCKET_NAME = 'peace-corps'
 AWS_MEDIA_BUCKET_NAME = 'pc-media-dev'
 AWS_STATIC_BUCKET_NAME = 'pc-theme-dev'

--- a/peacecorps/peacecorps/settings/production-admin.py
+++ b/peacecorps/peacecorps/settings/production-admin.py
@@ -6,11 +6,17 @@ INSTALLED_APPS += (
     'django.contrib.sessions',
     'django.contrib.messages',
     'tinymce',
+    'storages',
     'contenteditor',
 )
-# Set these only on the machines which have admin access
-LOGGED_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
-AWS_STORAGE_BUCKET_NAME = 'peace-corps'
+# Only media uploads are logged
+LOGGED_FILE_STORAGE = 'contenteditor.backends.MediaS3Storage'
+# We arsse not using this setting in favor of the two below it
+# AWS_STORAGE_BUCKET_NAME = 'peace-corps'
+AWS_MEDIA_BUCKET_NAME = 'pc-media-dev'
+AWS_STATIC_BUCKET_NAME = 'pc-theme-dev'
+STATICFILES_STORAGE = 'contenteditor.backends.StaticS3Storage'
+
 AWS_QUERYSTRING_AUTH = False
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID', '')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY', '')

--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -3,8 +3,6 @@ import os
 from .base import *
 
 
-INSTALLED_APPS += ('storages',)
-
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', '')
 ALLOWED_HOSTS = ['*']  # proxied
 
@@ -32,7 +30,8 @@ CACHES['midterm']['BACKEND'] = _backend
 CACHES['midterm']['LOCATION'] = '/tmp/midtermcache/'
 
 # Note that MEDIA_ROOT is not needed since we're using S3
-MEDIA_URL = '//peace-corps.s3.amazonaws.com/'
+MEDIA_URL = '//pc-media-dev.s3.amazonaws.com/'
+STATIC_URL = '//pc-theme-dev.s3.amazonaws.com/'
 
 GNUPG_HOME = os.environ.get('GNUPG_HOME', '')
 GPG_RECIPIENTS = {


### PR DESCRIPTION
- Create a mechanism for separating static and media files. The built in S3boto storage assumes a single bucket for both static assets (theme images, js, css, etc.) and media (image uploads). This commit uses different classes to get around that assumption, which could lead to clobbered files.
- Moved the inclusion of "storages" from all web servers to admin web servers -- there's no need to upload from anywhere else
- Renamed buckets we are using. These have been prepopulated with the appropriate files
- Configured all web servers to use the s3 bucket when serving static assets. The deployment process runs `collectstatic` on an admin server, sending all the static files to s3.
