### PR TITLE
Add field for country to campaign. Use that during synchronization

### DIFF
--- a/peacecorps/peacecorps/migrations/0035_auto_20141202_2354.py
+++ b/peacecorps/peacecorps/migrations/0035_auto_20141202_2354.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sirtrevor.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0034_auto_20141130_2254'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='campaign',
+            name='country',
+            field=models.ForeignKey(blank=True, to='peacecorps.Country', related_name='campaign', unique=True, null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='description',
+            field=sirtrevor.fields.SirTrevorField(help_text='the full description.'),
+        ),
+        migrations.AlterField(
+            model_name='media',
+            name='description',
+            field=models.TextField(help_text="Provide an image description for users with screenreaders.         If the image has text, transcribe the text here. If it's a photo,         briefly describe what it depicts. Do not use html formatting."),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -62,13 +62,13 @@ class Account(models.Model):
     def percent_funded(self):
         if self.goal:
             return percentfunded(self.total() + self.community_contribution,
-                             self.goal + self.community_contribution)
+                                 self.goal + self.community_contribution)
         else:
             return 0
 
     def percent_community_funded(self):
         return percentfunded(self.community_contribution,
-                self.goal + self.community_contribution)
+                             self.goal + self.community_contribution)
 
     def funded(self):
         if self.goal and self.total() >= self.goal:
@@ -129,6 +129,8 @@ class Campaign(models.Model):
         max_length=100, unique=True)
     description = SirTrevorField(help_text="the full description.")
     featuredprojects = models.ManyToManyField('Project', blank=True, null=True)
+    country = models.ForeignKey(
+        'Country', related_name="campaign", blank=True, null=True, unique=True)
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
We need a way to grab country funds' associated country picture. Instead of using an ugly `LIKE` query, this explicitly stores the relevant country on the campaign object.

For now, it's unique (as only country funds use it), but we could remove that restriction if the country associated with memorial funds becomes relevant.

You'll notice some migrations to other fields; those are just description edits that weren't in `master`'s migrations.
