### PR TITLE
Thank you page templates

### DIFF
--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from xml.etree.ElementTree import Element, SubElement, tostring
+from urllib.parse import urlencode
 from uuid import uuid4
 
 from django.conf import settings
@@ -117,15 +118,18 @@ def generate_custom_fields(data):
     return custom
 
 
-def redirect_urls(account):
-    """Success and return URLs are derived from the account"""
+def redirect_urls(account, donor_name):
+    """Success and return URLs are derived from the account. Also the
+    donor's first name to the url"""
     if account.category == Account.PROJECT:
         project = account.project_set.first()
-        return (reverse('project success', kwargs={'slug': project.slug}),
+        return (reverse('project success', kwargs={'slug': project.slug})
+                + '?' + urlencode({'donor_name': donor_name}),
                 reverse('project failure', kwargs={'slug': project.slug}))
     else:
         campaign = account.campaign_set.first()
-        return (reverse('campaign success', kwargs={'slug': campaign.slug}),
+        return (reverse('campaign success', kwargs={'slug': campaign.slug})
+                + '?' + urlencode({'donor_name': donor_name}),
                 reverse('campaign failure', kwargs={'slug': campaign.slug}))
 
 
@@ -137,8 +141,10 @@ def convert_to_paygov(data, account, callback_base):
     data['agency_tracking_id'] = tracking_id
     data['agency_memo'] = generate_agency_memo(data)
     data['form_id'] = settings.PAY_GOV_FORM_ID
+    # quick method of finding the donor's first name
+    donor_first = data.get('payer_name', '').split(' ')[0]
     data['success_url'], data['failure_url'] = (
-        callback_base + url for url in redirect_urls(account))
+        callback_base + url for url in redirect_urls(account, donor_first))
     data.update(generate_custom_fields(data))
     xml = generate_collection_request(data)
     return DonorInfo(agency_tracking_id=tracking_id, account=account,

--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -125,19 +125,8 @@ def redirect_urls(account):
                 reverse('project failure', kwargs={'slug': project.slug}))
     else:
         campaign = account.campaign_set.first()
-        mapping = {Account.COUNTRY: 'country', Account.MEMORIAL: 'memorial',
-                   Account.OTHER: 'general'}
-        if account.category in mapping:
-            ident = mapping[account.category]
-            return (reverse(ident + ' success',
-                            kwargs={'slug': campaign.slug}),
-                    reverse(ident + ' failure',
-                            kwargs={'slug': campaign.slug}))
-        else:
-            return (reverse('campaign success',
-                            kwargs={'slug': campaign.slug}),
-                    reverse('campaign failure',
-                            kwargs={'slug': campaign.slug}))
+        return (reverse('campaign success', kwargs={'slug': campaign.slug}),
+                reverse('campaign failure', kwargs={'slug': campaign.slug}))
 
 
 def convert_to_paygov(data, account, callback_base):

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -33,6 +33,17 @@ TEMPLATE_LOADERS = (
     'django_jinja.loaders.AppLoader',
     'django_jinja.loaders.FileSystemLoader',
 )
+# Default + request
+TEMPLATE_CONTEXT_PROCESSORS = (
+    "django.contrib.auth.context_processors.auth",
+    "django.core.context_processors.debug",
+    "django.core.context_processors.i18n",
+    "django.core.context_processors.media",
+    "django.core.context_processors.static",
+    "django.core.context_processors.tz",
+    "django.contrib.messages.context_processors.messages",
+    "django.core.context_processors.request",
+)
 
 INSTALLED_APPS += ('django_jinja',)
 DEFAULT_JINJA2_TEMPLATE_EXTENSION = '.jinja'
@@ -122,3 +133,6 @@ LOGGED_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 # Set SIRTREVOR var to exclude sirtrevor urls
 # (overwritten in admin settings)
 SIRTREVOR = False
+
+# Used when generating tweets
+SHARE_TEMPLATE = "I just donated to a great cause! %s"

--- a/peacecorps/peacecorps/templates/donations/campaign_success.jinja
+++ b/peacecorps/peacecorps/templates/donations/campaign_success.jinja
@@ -1,9 +1,46 @@
 {% extends "donations/base.jinja" %}
 
-{% block title %}Peace Corps - Donation Success{% endblock %}
-{% block header %}Peace Corps - Donation Success{% endblock %}
+{% block title %}Peace Corps | Thank You{% endblock %}
+{% block header %}Peace Corps | Thank You{% endblock %}
+{% block content_class %}thankyou{% endblock %}
 
 {% block content %}
-<h2>{{campaign.name}}</h2>
+<section class="section">
+  <div class="section__content u-clearfix">
+    <article class="inset inset--sm">
+      {% if request.GET.donor_name %}
+        <h2>Thank you, {{ request.GET.donor_name }}!</h2>
+      {% else %}
+        <h2>Thank you!</h2>
+      {% endif %}
+      Your donation to the {{campaign.name}} will go to help our volunteer
+      projects.
+    </article>
+    <div class="inset inset--sm">Tell Your Friends</div>
+    <ul class="inset inset--sm">
+      <li class="main_nav__link"
+          ><a target="_blank"
+              href="//www.facebook.com/sharer/sharer.php?u={{share_url|urlencode}}"
+              >Facebook</a></li>
+      <li class="main_nav__link"
+          ><a target="_blank"
+              href="//twitter.com/intent/tweet?text={{share_text|urlencode}}"
+              >Twitter</a></li>
+    </ul>
+  </div>
+</section>
+
+<a href="{{url("donate campaign", slug=campaign.slug)}}" class="t-title--4"
+   >View Fund</a>
+<section class="section">
+  <div class="section__content u-clearfix">
+    <div class="inset inset--sm">
+      {# @TODO Photo #}
+      <div>You Helped Support This</div>
+      <h3>{{campaign.name}}</h2>
+      {{campaign.description.html|safe}}
+    </div>
+  </div>
+</section>
 {% endblock %}
 

--- a/peacecorps/peacecorps/templates/donations/project_success.jinja
+++ b/peacecorps/peacecorps/templates/donations/project_success.jinja
@@ -1,8 +1,70 @@
 {% extends "donations/base.jinja" %}
 
-{% block title %}Peace Corps - Donation Success{% endblock %}
-{% block header %}Peace Corps - Donation Success{% endblock %}
+{% block title %}Peace Corps | Thank You{% endblock %}
+{% block header %}Peace Corps | Thank You{% endblock %}
+{% block content_class %}thankyou{% endblock %}
 
 {% block content %}
-{% include "donations/includes/project-top.jinja" %}
+<section class="section">
+  <div class="section__content u-clearfix">
+    <article class="inset inset--sm">
+      {% if request.GET.donor_name %}
+        <h2>Thank you, {{ request.GET.donor_name }}!</h2>
+      {% else %}
+        <h2>Thank you!</h2>
+      {% endif %}
+      Your donation is helping promote {{project.issue().name}} in
+      {{project.country.name}}.
+    </article>
+    <div class="inset inset--sm">Tell Your Friends</div>
+    <ul class="inset inset--sm">
+      <li class="main_nav__link"
+          ><a target="_blank"
+              href="//www.facebook.com/sharer/sharer.php?u={{share_url|urlencode}}"
+              >Facebook</a></li>
+      <li class="main_nav__link"
+          ><a target="_blank"
+              href="//twitter.com/intent/tweet?text={{share_text|urlencode}}"
+              >Twitter</a></li>
+    </ul>
+  </div>
+</section>
+
+<a href="{{url("donate project", slug=project.slug)}}" class="t-title--4"
+   >View Project</a>
+
+<section class="section">
+  <div class="section__content u-clearfix">
+    <div class="inset inset--sm">
+      {# @TODO Photo #}
+      <div>You Helped Fund This Project</div>
+      <h3>{{project.title}}</h2>
+      <section class="blurb">
+        <section class="u-align_c">
+            <div class="mask mask--oval mask--bordered u-h_center--block">
+              <img class="mask__content"
+                   src="{{project.volunteerpicture.url}}"
+                   alt="{{project.volunteerpicture.description}}">
+            </div>
+          <span class="t-body--sm"><strong>{{project.volunteername}}</strong><br>
+            volunteer from <strong>{{project.volunteerhomestate}}</strong>
+          </span>
+        </section>
+        <section class="u-align_c">
+          <div class="mask mask--oval mask--bordered u-h_center--block map">
+            <img src="{{ static("peacecorps/img/countries/"
+                                + project.country.code.lower() + ".svg") }}"
+                 class="mask__content" />
+          </div>
+            <span class="t-body--sm">
+              in <strong>{{project.country.name}}</strong>
+            </span>
+        </section>
+        <section class="u-align_c">
+          {# radial progress #}
+        </section>
+      </section>
+    </div>
+  </div>
+</section>
 {% endblock %}

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote as urlquote
+
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 
@@ -89,7 +91,7 @@ class DonationsTests(TestCase):
     def test_bad_request_donations(self):
         """ The donation information page should 400 if donation amount and
         project code aren't included. """
-        response = self.client.get('/donations/contribute')
+        response = self.client.get('/donations/contribute/')
         self.assertEqual(response.status_code, 400)
 
     def test_bad_amount(self):
@@ -115,11 +117,11 @@ class DonatePagesTests(TestCase):
 
     # Do the pages load without error?
     def test_pages_rendering(self):
-        response = self.client.get('/donate')
+        response = self.client.get('/donate/')
         self.assertEqual(response.status_code, 200)
 
     def test_project_rendering(self):
-        response = self.client.get('/donate/project/brick-oven-bakery')
+        response = self.client.get('/donate/project/brick-oven-bakery/')
         self.assertEqual(response.status_code, 200)
 
     def test_fund_rendering(self):
@@ -141,19 +143,19 @@ class DonatePagesTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_project_form_empty_amount(self):
-        response = self.client.post('/donate/project/brick-oven-bakery',
+        response = self.client.post('/donate/project/brick-oven-bakery/',
                                     {'presets': 'custom',
                                      'payment_amount': ''})
         self.assertEqual(response.status_code, 200)
 
     def test_project_form_low_amount(self):
-        response = self.client.post('/donate/project/brick-oven-bakery',
+        response = self.client.post('/donate/project/brick-oven-bakery/',
                                     {'presets': 'custom',
                                      'payment_amount': '0.99'})
         self.assertEqual(response.status_code, 200)
 
     def test_project_form_high_amount(self):
-        response = self.client.post('/donate/project/brick-oven-bakery',
+        response = self.client.post('/donate/project/brick-oven-bakery/',
                                     {'presets': 'custom',
                                      'payment_amount': '10000.00'})
         self.assertEqual(response.status_code, 200)
@@ -161,7 +163,7 @@ class DonatePagesTests(TestCase):
     def test_project_form_redirect_custom(self):
         """When selecting the fund-a-custom-amount option, everything should
         work"""
-        response = self.client.post('/donate/project/brick-oven-bakery',
+        response = self.client.post('/donate/project/brick-oven-bakery/',
                                     {'presets': 'custom',
                                      'payment_amount': '123.45'})
         self.assertEqual(response.status_code, 302)
@@ -258,3 +260,11 @@ class DonatePagesTests(TestCase):
         response = self.client.get(reverse('donate special funds'))
         self.assertNotContains(response, 'Stephanie Brown Memorial Fund')
         self.assertContains(response, 'Stephanie Brown')
+
+    def test_success_render(self):
+        """Verify that the donor's name and share links are present"""
+        url = reverse('campaign success', kwargs={'slug': 'education'})
+        url += '?donor_name=Billy'
+        response = self.client.get(url, HTTP_HOST='example.com')
+        self.assertContains(response, 'Thank you, Billy')
+        self.assertContains(response, urlquote('http://example.com/'))

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -247,6 +247,12 @@ class DonatePagesTests(TestCase):
                         url, data={'agency_tracking_id': 'NEVERUSED'})
                     self.assertEqual(response.status_code, 302)
                     self.assertTrue(url in response['LOCATION'])
+                    response = client.post(
+                        url + '?something=else',
+                        data={'agency_tracking_id': 'NEVERUSED'})
+                    self.assertEqual(response.status_code, 302)
+                    self.assertTrue(url in response['LOCATION'])
+                    self.assertTrue('?something=else' in response['LOCATION'])
 
     def test_memorial_fund_name(self):
         response = self.client.get(reverse('donate special funds'))

--- a/peacecorps/peacecorps/tests/test_xmlgen.py
+++ b/peacecorps/peacecorps/tests/test_xmlgen.py
@@ -153,35 +153,9 @@ class PayXMLGenerationTests(TestCase):
         account.category = Account.COUNTRY
         succ, fail = payxml.redirect_urls(account)
         self.assertTrue('success' in succ)
-        self.assertTrue('country' in succ)
+        self.assertTrue('fund' in succ)
         self.assertTrue('failure' in fail)
-        self.assertTrue('country' in fail)
-
-        account.category = Account.MEMORIAL
-        succ, fail = payxml.redirect_urls(account)
-        self.assertTrue('success' in succ)
-        self.assertTrue('memorial' in succ)
-        self.assertTrue('failure' in fail)
-        self.assertTrue('memorial' in fail)
-
-        account.category = Account.SECTOR
-        succ, fail = payxml.redirect_urls(account)
-        self.assertTrue('success' in succ)
-        self.assertTrue('campaign' in succ)
-        self.assertTrue('failure' in fail)
-        self.assertTrue('campaign' in fail)
-
-        # the url for "general"/other funds does not have an identifier
-        account.category = Account.OTHER
-        succ, fail = payxml.redirect_urls(account)
-        self.assertTrue('success' in succ)
-        self.assertFalse('country' in succ)
-        self.assertFalse('memorial' in succ)
-        self.assertFalse('campaign' in succ)
-        self.assertTrue('failure' in fail)
-        self.assertFalse('country' in fail)
-        self.assertFalse('memorial' in fail)
-        self.assertFalse('campaign' in fail)
+        self.assertTrue('fund' in fail)
 
         campaign.delete()
         account.delete()

--- a/peacecorps/peacecorps/tests/test_xmlgen.py
+++ b/peacecorps/peacecorps/tests/test_xmlgen.py
@@ -143,17 +143,19 @@ class PayXMLGenerationTests(TestCase):
         campaign = Campaign.objects.create(
             account=account, slug='cccccc')
 
-        succ, fail = payxml.redirect_urls(account)
+        succ, fail = payxml.redirect_urls(account, "Bob/Mary")
         self.assertTrue('success' in succ)
         self.assertTrue('project' in succ)
+        self.assertTrue('Bob%2FMary' in succ)
         self.assertTrue('failure' in fail)
         self.assertTrue('project' in fail)
         proj.delete()
 
         account.category = Account.COUNTRY
-        succ, fail = payxml.redirect_urls(account)
+        succ, fail = payxml.redirect_urls(account, "Bob+Mary")
         self.assertTrue('success' in succ)
         self.assertTrue('fund' in succ)
+        self.assertTrue('Bob%2BMary' in succ)
         self.assertTrue('failure' in fail)
         self.assertTrue('fund' in fail)
 

--- a/peacecorps/peacecorps/urls.py
+++ b/peacecorps/peacecorps/urls.py
@@ -11,49 +11,49 @@ _slug = r'(?P<slug>[a-zA-Z0-9_-]+)'
 
 urlpatterns = patterns(
     '',
-    url(r'^donate/?$', midterm_cache(views.donate_landing),
+    url(r'^donate/$', midterm_cache(views.donate_landing),
         name='donate landing'),
-    url(r'^donate/projects-funds/?$',
+    url(r'^donate/projects-funds/$',
         midterm_cache(views.donate_projects_funds),
         name='donate projects funds'),
-    url(r'^donate/projects-funds/special/?$',
+    url(r'^donate/projects-funds/special/$',
         midterm_cache(views.special_funds), name='donate special funds'),
 
-    url(r'^donate/fund/' + _slug + r'/?$',
+    url(r'^donate/fund/' + _slug + r'/$',
         midterm_cache(views.fund_detail), name='donate campaign'),
     # not cached so the values are up-to-date
-    url(r'^donate/fund/' + _slug + r'/success/?$',
+    url(r'^donate/fund/' + _slug + r'/success/$',
         views.CampaignReturn.as_view(
             template_name='donations/campaign_success.jinja'),
         name='campaign success'),
-    url(r'^donate/fund/' + _slug + r'/failure/?$',
+    url(r'^donate/fund/' + _slug + r'/failure/$',
         views.CampaignReturn.as_view(
             template_name='donations/campaign_failure.jinja'),
         name='campaign failure'),
 
-    url(r'^donate/project/' + _slug + r'/?$',
+    url(r'^donate/project/' + _slug + r'/$',
         midterm_cache(views.donate_project), name='donate project'),
     # not cached so the values are up-to-date
-    url(r'^donate/project/' + _slug + r'/success/?$',
+    url(r'^donate/project/' + _slug + r'/success/$',
         views.ProjectReturn.as_view(
             template_name='donations/project_success.jinja'),
         name='project success'),
-    url(r'^donate/project/' + _slug + r'/failure/?$',
+    url(r'^donate/project/' + _slug + r'/failure/$',
         views.ProjectReturn.as_view(
             template_name='donations/project_failure.jinja'),
         name='project failure'),
 
-    url(r'^donations/contribute/?$', midterm_cache(views.donation_payment),
+    url(r'^donations/contribute/$', midterm_cache(views.donation_payment),
         name='donations_payment'),
     # not cached so the values are up-to-date
-    url(r'^success/?$',
+    url(r'^success/$',
         TemplateView.as_view(template_name='donations/success.jinja'),
         name='donation success'),
-    url(r'^failure/?$',
+    url(r'^failure/$',
         TemplateView.as_view(template_name='donations/failure.jinja'),
         name='donation failure'),
 
-    url(r'^api/account/' + _slug + r'/?$',
+    url(r'^api/account/' + _slug + r'/$',
         shortterm_cache(api.GetAccountPercent.as_view())),
 )
 

--- a/peacecorps/peacecorps/urls.py
+++ b/peacecorps/peacecorps/urls.py
@@ -22,11 +22,11 @@ urlpatterns = patterns(
     url(r'^donate/fund/' + _slug + r'/?$',
         midterm_cache(views.fund_detail), name='donate campaign'),
     # not cached so the values are up-to-date
-    url(r'^donate/campaign/' + _slug + r'/success/?$',
+    url(r'^donate/fund/' + _slug + r'/success/?$',
         views.CampaignReturn.as_view(
             template_name='donations/campaign_success.jinja'),
         name='campaign success'),
-    url(r'^donate/campaign/' + _slug + r'/failure/?$',
+    url(r'^donate/fund/' + _slug + r'/failure/?$',
         views.CampaignReturn.as_view(
             template_name='donations/campaign_failure.jinja'),
         name='campaign failure'),
@@ -42,36 +42,6 @@ urlpatterns = patterns(
         views.ProjectReturn.as_view(
             template_name='donations/project_failure.jinja'),
         name='project failure'),
-
-    # not cached so the values are up-to-date
-    url(r'^donate/country/' + _slug + r'/success/?$',
-        views.CampaignReturn.as_view(
-            template_name='donations/campaign_success.jinja'),
-        name='country success'),
-    url(r'^donate/country/' + _slug + r'/failure/?$',
-        views.CampaignReturn.as_view(
-            template_name='donations/campaign_failure.jinja'),
-        name='country failure'),
-
-    # not cached so the values are up-to-date
-    url(r'^donate/memorial/' + _slug + r'/success/?$',
-        views.CampaignReturn.as_view(
-            template_name='donations/campaign_success.jinja'),
-        name='memorial success'),
-    url(r'^donate/memorial/' + _slug + r'/failure/?$',
-        views.CampaignReturn.as_view(
-            template_name='donations/campaign_failure.jinja'),
-        name='memorial failure'),
-    # this needs to be below other donate urls.
-    # not cached so the values are up-to-date
-    url(r'^donate/' + _slug + r'/success/?$',
-        views.CampaignReturn.as_view(
-            template_name='donations/campaign_success.jinja'),
-        name='general success'),
-    url(r'^donate/' + _slug + r'/failure/?$',
-        views.CampaignReturn.as_view(
-            template_name='donations/campaign_failure.jinja'),
-        name='general failure'),
 
     url(r'^donations/contribute/?$', midterm_cache(views.donation_payment),
         name='donations_payment'),

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -199,25 +199,37 @@ def fund_detail(request, slug):
         })
 
 
-class ProjectReturn(DetailView):
+class AbstractReturn(DetailView):
+    """Shared by views related to users returning from pay.gov. This includes
+    success/failure pages for projects/funds"""
+    def post(self, request, *args, **kwargs):
+        path = request.path
+        params = request.GET.urlencode()
+        if params:
+            path += "?" + params
+        return HttpResponseRedirect(path)
+
+    @csrf_exempt
+    def dispatch(self, *args, **kwargs):
+        return super(AbstractReturn, self).dispatch(*args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        """Must add sharing link info"""
+        context = super(AbstractReturn, self).get_context_data(**kwargs)
+        path = self.request.scheme + "://" + self.request.get_host()
+        path += reverse("donate " +
+                        self.get_context_object_name(context['object']),
+                        kwargs={'slug': context['object'].slug})
+        context['share_url'] = path
+        context['share_text'] = settings.SHARE_TEMPLATE % path
+        return context
+
+
+class ProjectReturn(AbstractReturn):
     queryset = Project.objects.select_related(
         'account', 'country', 'featured_image', 'overflow',
         'volunteerpicture')
 
-    def post(self, request, *args, **kwargs):
-        return HttpResponseRedirect(request.path)
 
-    @csrf_exempt
-    def dispatch(self, *args, **kwargs):
-        return super(ProjectReturn, self).dispatch(*args, **kwargs)
-
-
-class CampaignReturn(DetailView):
+class CampaignReturn(AbstractReturn):
     queryset = Campaign.objects.select_related('account', 'featured_image')
-
-    def post(self, request, *args, **kwargs):
-        return HttpResponseRedirect(request.path)
-
-    @csrf_exempt
-    def dispatch(self, *args, **kwargs):
-        return super(CampaignReturn, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
- Removes distinct thank you/failure pages for different fund types; all run through a single url/template now
- Enforce trailing slash; other pages will be automatically redirected
- Passes along the donor's first name with the url. This will be checked when rendering the success page
- Add the request to the context middleware -- making the above possible
- Simple templates for the projects and fund thank you pages
- Links to facebook/twitter, sharing the project/fund's "detail" view
- Setting to edit the twitter share text
