### PR TITLE
Faqs Template

### DIFF
--- a/peacecorps/contenteditor/admin.py
+++ b/peacecorps/contenteditor/admin.py
@@ -1,3 +1,4 @@
+from adminsortable.admin import SortableAdminMixin
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
@@ -41,6 +42,10 @@ class VignetteAdmin(admin.ModelAdmin):
         return False
 
 
+class FAQAdmin(SortableAdminMixin, admin.ModelAdmin):
+    pass
+
+
 admin.site.register(models.Campaign, CampaignAdmin)
 admin.site.register(models.Country)
 admin.site.register(models.FeaturedCampaign)
@@ -50,6 +55,7 @@ admin.site.register(models.Media)
 admin.site.register(models.Project, ProjectAdmin)
 admin.site.register(models.Vignette, VignetteAdmin)
 admin.site.register(models.Issue)
+admin.site.register(models.FAQ, FAQAdmin)
 admin.site.unregister(User)
 admin.site.register(User, StrictUserAdmin)
 admin.site.login_form = LoggingAuthenticationForm

--- a/peacecorps/contenteditor/urls.py
+++ b/peacecorps/contenteditor/urls.py
@@ -20,6 +20,8 @@ def _wrap(callback):
             return callback(request, *args, **kwargs)
         else:   # Password expired and not in whitelist
             return HttpResponseRedirect(pass_change_url)
+    if hasattr(callback, 'csrf_exempt'):
+        inner.csrf_exempt = callback.csrf_exempt
     return inner
 
 

--- a/peacecorps/peacecorps/fixtures/initial_faqs.yaml
+++ b/peacecorps/peacecorps/fixtures/initial_faqs.yaml
@@ -1,0 +1,48 @@
+- fields: {answer: '{"data":[{"type":"text","data":{"text":"A women''s development
+      NGO works with women living in Shirak Marz to overcome psychological and economic
+      hardship. Towards this end, the NGO gives them the tools to identify and solve
+      their communities'' problems. As in many places around the world, this region
+      has high unemployment.\n"}}]}', order: 2, question: 'Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod?'}
+  model: peacecorps.faq
+  pk: 1
+- fields: {answer: '{"data":[{"type":"text","data":{"text":"A women''s development
+      NGO works with women living in Shirak Marz to overcome psychological and economic
+      hardship. Towards this end, the NGO gives them the tools to identify and solve
+      their communities'' problems. As in many places around the world, this region
+      has high unemployment.\n"}}]}', order: 1, question: 'Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod?'}
+  model: peacecorps.faq
+  pk: 2
+- fields: {answer: '{"data":[{"type":"text","data":{"text":"A women''s development
+      NGO works with women living in Shirak Marz to overcome psychological and economic
+      hardship. Towards this end, the NGO gives them the tools to identify and solve
+      their communities'' problems. As in many places around the world, this region
+      has high unemployment\n"}}]}', order: 3, question: 'Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod?'}
+  model: peacecorps.faq
+  pk: 3
+- fields: {answer: '{"data":[{"type":"text","data":{"text":"A women''s development
+      NGO works with women living in Shirak Marz to overcome psychological and economic
+      hardship. Towards this end, the NGO gives them the tools to identify and solve
+      their communities'' problems. As in many places around the world, this region
+      has high unemployment.\n"}}]}', order: 4, question: 'Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod?'}
+  model: peacecorps.faq
+  pk: 4
+- fields: {answer: '{"data":[{"type":"text","data":{"text":"A women''s development
+      NGO works with women living in Shirak Marz to overcome psychological and economic
+      hardship. Towards this end, the NGO gives them the tools to identify and solve
+      their communities'' problems. As in many places around the world, this region
+      has high unemployment.\n"}}]}', order: 5, question: 'Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod?'}
+  model: peacecorps.faq
+  pk: 5
+- fields: {answer: '{"data":[{"type":"text","data":{"text":"A women''s development
+      NGO works with women living in Shirak Marz to overcome psychological and economic
+      hardship. Towards this end, the NGO gives them the tools to identify and solve
+      their communities'' problems. As in many places around the world, this region
+      has high unemployment.\n"}}]}', order: 6, question: 'Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod?'}
+  model: peacecorps.faq
+  pk: 6

--- a/peacecorps/peacecorps/migrations/0045_faq.py
+++ b/peacecorps/peacecorps/migrations/0045_faq.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import peacecorps.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0044_project_abstract'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='FAQ',
+            fields=[
+                ('id', models.AutoField(serialize=False, auto_created=True, primary_key=True, verbose_name='ID')),
+                ('question', models.CharField(max_length=256)),
+                ('answer', peacecorps.fields.BraveSirTrevorField()),
+                ('order', models.PositiveIntegerField(default=0)),
+            ],
+            options={
+                'ordering': ('order',),
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -359,3 +359,15 @@ class Vignette(models.Model):
                 {'type': 'text', 'data': {
                     'text': 'Missing Vignette `' + slug + '`'}}]}))
         return vig
+
+
+class FAQ(models.Model):
+    question = models.CharField(max_length=256)
+    answer = BraveSirTrevorField()
+    order = models.PositiveIntegerField(default=0, blank=False, null=False)
+
+    class Meta(object):
+        ordering = ('order', )
+
+    def __str__(self):
+        return self.question

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -23,6 +23,7 @@ INSTALLED_APPS = (
     'restless',
     'sirtrevor',
     'peacecorps',
+    'adminsortable',
 )
 
 

--- a/peacecorps/peacecorps/templates/donations/donate_landing.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_landing.jinja
@@ -51,7 +51,7 @@
       <a href="{{url("donate projects funds")}}">
         Projects and Funds</a></li>
     <li class="main_nav__link t-title--4">
-      <a href="#">
+      <a href="{{url("donate faqs")}}">
         Donating FAQs</a></li>
   </ul>
 </nav>
@@ -126,7 +126,8 @@
         amet, lorem ipseum dolor amet, lorem.</h2>
     </div>
     <aside class="section">
-      <h2 class="t-title--2 u-pullr"><a href="#">Donating FAQs</h2></a></h2>
+      <h2 class="t-title--2 u-pullr"
+          ><a href="{{url("donate faqs")}}">Donating FAQs</h2></a></h2>
     </aside>
   </div>
 </section>

--- a/peacecorps/peacecorps/templates/donations/faq.jinja
+++ b/peacecorps/peacecorps/templates/donations/faq.jinja
@@ -1,0 +1,35 @@
+{% extends "donations/base.jinja" %}
+
+{% block title %}Peace Corps | Donating FAQs{% endblock %}
+{% block header %}Peace Corps | Donating FAQs{% endblock %}
+{% block content_class %}faqs{% endblock %}
+
+{% block content %}
+<section class="section">
+  <div class="section__content u-clearfix">
+    <p class="inset inset--md">
+      Wondering where your money goes once you donate to us? Or lorem ipsum
+      dolor amet? Browse these questions, and if you can't find your answer,
+      feel free to <a href="mailto:donations@peacecorps.gov">email us</a>.
+    </p>
+  </div>
+</section>
+<section class="js-discoverApp">
+  <ul>
+    {% for faq in object_list %}
+      <li>
+        <header>
+          <a aria-expanded="false" href="#"
+             aria-controls="collapsible-{{faq.pk}}">{{faq.question}}</a>
+        </header>
+        <article class="js-collapsibleItem" id="collapsible-{{faq.pk}}"
+                 aria-hidden="true">
+          <h3>{{faq.question}}</h3>
+          {{faq.answer.html|safe}}
+        </article>
+      </li>
+  {% endfor %}
+</section>
+<a href="{{url("donate projects funds")}}" class="t-title--4"
+   >Explore Projects and Funds</a>
+{% endblock %}

--- a/peacecorps/peacecorps/urls.py
+++ b/peacecorps/peacecorps/urls.py
@@ -18,6 +18,8 @@ urlpatterns = patterns(
         name='donate projects funds'),
     url(r'^donate/projects-funds/special/$',
         midterm_cache(views.special_funds), name='donate special funds'),
+    url(r'^donate/faq/$', midterm_cache(views.FAQs.as_view()),
+        name='donate faqs'),
 
     url(r'^donate/fund/' + _slug + r'/$',
         midterm_cache(views.fund_detail), name='donate campaign'),

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -4,12 +4,12 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
-from django.views.generic import DetailView
+from django.views.generic import DetailView, ListView
 from django.views.decorators.csrf import csrf_exempt
 
 from peacecorps.forms import DonationAmountForm, DonationPaymentForm
 from peacecorps.models import (
-    Account, Campaign, FeaturedCampaign, FeaturedProjectFrontPage,
+    Account, Campaign, FAQ, FeaturedCampaign, FeaturedProjectFrontPage,
     Issue, humanize_amount, Project, Vignette)
 from peacecorps.payxml import convert_to_paygov
 
@@ -236,3 +236,8 @@ class ProjectReturn(AbstractReturn):
 
 class CampaignReturn(AbstractReturn):
     queryset = Campaign.objects.select_related('account', 'featured_image')
+
+
+class FAQs(ListView):
+    model = FAQ
+    template_name = 'donations/faq.jinja'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ pytz
 psycopg2==2.5.3
 boto
 python-logstash
+django-admin-sortable2
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
 -e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages


### PR DESCRIPTION
- Creates a new model for FAQ objects
- Adds that model to the admin with a sortable interface
- Adds a template/url for faqs
- Fixes a bug where admin pages weren't getting the correct csrf exemption
- Bases the faq collapse/expand directly off of that used on the project sorter. This will need to be reworked
