### PR TITLE
Import campaigns as json

### DIFF
--- a/peacecorps/peacecorps/management/commands/sync_accounting.py
+++ b/peacecorps/peacecorps/management/commands/sync_accounting.py
@@ -81,7 +81,9 @@ def create_campaign(account, row, name, acc_type):
     account.save()
     campaign = Campaign.objects.create(
         name=name, account=account, campaigntype=acc_type,
-        description=row['SUMMARY'], country=country)
+        description=json.dumps({"data": [{"type": "text",
+                                          "data": {"text": row['SUMMARY']}}]}),
+        country=country)
     if acc_type == Account.SECTOR:
         # Make sure we remember the sector this is marked as
         SectorMapping.objects.create(pk=row['SECTOR'], campaign=campaign)

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -217,7 +217,7 @@ class SyncAccountingTests(TestCase):
 
     def test_create_campaign(self):
         """Verify that country funds have the correct country, and other funds
-        have none"""
+        have none. Also verify summary is json"""
         acc1 = Account.objects.create(name='acc1', code='111-111')
         row = {'PROJ_NAME1': 'China Fund', 'PROJ_NO': 'CFD-111',
                'LOCATION': 'CHINA', 'SUMMARY': 'Ssssss'}
@@ -232,6 +232,9 @@ class SyncAccountingTests(TestCase):
                              Account.MEMORIAL)
         campaign = Campaign.objects.filter(name='Smith Memorial Fund').first()
         self.assertEqual(None, campaign.country)
+        self.assertEqual(
+            {"data": [{"type": "text", "data": {"text": "Ssssss"}}]},
+            json.loads(campaign.description))
         acc1.delete()
         acc2.delete()
 


### PR DESCRIPTION
We were importing campaign summaries as text, which then exploded when trying to render them using the Sir Trevor field.
