### PR TITLE
Resize to the cloud

### DIFF
--- a/peacecorps/contenteditor/imagesizing.py
+++ b/peacecorps/contenteditor/imagesizing.py
@@ -1,18 +1,16 @@
-from PIL import Image
-from django.core.files.uploadedfile import SimpleUploadedFile
-
 from django.conf import settings
-import pdb
+from PIL import Image
 
-def image_sizes(file_):
+
+def resize(file_):
 
     def resize(image, size, ext, filename):
         image.thumbnail(size, Image.ANTIALIAS)
 
         path = settings.MEDIA_ROOT + settings.SIRTREVOR_UPLOAD_PATH
 
-        image.save(path+filename+'-'+ext+'.'+ image.format.lower(),
-            image.format)
+        image.save(path+filename + '-' + ext + '.' + image.format.lower(),
+                   image.format)
         return None
 
     filename = file_.name.split('.')[0]
@@ -29,4 +27,3 @@ def image_sizes(file_):
     resize(im, thm, 'thm', filename)
 
     return file_
-

--- a/peacecorps/contenteditor/imagesizing.py
+++ b/peacecorps/contenteditor/imagesizing.py
@@ -1,29 +1,29 @@
+import os
+import tempfile
+
 from django.conf import settings
+from django.core.files.storage import default_storage
 from PIL import Image
 
 
-def resize(file_):
+# We'll be mutating an image, so scale from larger to smaller
+SIZES = (('lg', 1200, 1200), ('md', 900, 900), ('sm', 500, 500),
+         ('thm', 300, 300))
 
-    def resize(image, size, ext, filename):
-        image.thumbnail(size, Image.ANTIALIAS)
 
-        path = settings.MEDIA_ROOT + settings.SIRTREVOR_UPLOAD_PATH
+def resize(original_file):
+    """When an image has been uploaded, resize it to thumbnails, etc."""
 
-        image.save(path+filename + '-' + ext + '.' + image.format.lower(),
-                   image.format)
-        return None
+    filename = original_file.name.split('.')[0]
 
-    filename = file_.name.split('.')[0]
+    image = Image.open(original_file)
+    for ext, width, height in SIZES:
+        with tempfile.TemporaryFile() as buffer_file:
+            image.thumbnail((width, height), Image.ANTIALIAS)
+            path = os.path.join(
+                settings.SIRTREVOR_UPLOAD_PATH,
+                filename + '-' + ext + '.' + image.format.lower())
+            image.save(buffer_file, image.format.lower())
+            default_storage.save(path, buffer_file)
 
-    lg = (1200, 1200)
-    md = (900, 900)
-    sm = (500, 500)
-    thm = (300, 300)
-
-    im = Image.open(file_)
-    resize(im, lg, 'lg', filename)
-    resize(im, md, 'md', filename)
-    resize(im, sm, 'sm', filename)
-    resize(im, thm, 'thm', filename)
-
-    return file_
+    return original_file

--- a/peacecorps/contenteditor/tests/test_imagesizing.py
+++ b/peacecorps/contenteditor/tests/test_imagesizing.py
@@ -1,0 +1,17 @@
+import os
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from contenteditor import imagesizing
+
+
+class ResizeTests(TestCase):
+    @patch('contenteditor.imagesizing.default_storage')
+    def test_resize_saved(self, default_storage):
+        """Verify that the default storage is getting all three images"""
+        path = os.path.join('peacecorps', 'static', 'peacecorps', 'img',
+                            'pc_logo.png')
+        original = open(path, 'rb')
+        imagesizing.resize(original)
+        self.assertTrue(default_storage.save.call_count, 4)

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -137,7 +137,7 @@ SIRTREVOR = False
 
 # Sir Trevor image storage and processing:
 SIRTREVOR_UPLOAD_PATH = "attachments/"
-SIRTREVOR_ATTACHMENT_PROCESSOR = 'peacecorps.utils.image_sizes'
+SIRTREVOR_ATTACHMENT_PROCESSOR = 'contenteditor.imagesizing.resize'
 
 # Used when generating tweets
 SHARE_TEMPLATE = "I just donated to a great cause! %s"


### PR DESCRIPTION
Moves resizing code into `contenteditor` app. Makes it work with the default storage (allowing it to send to S3)

These resized images aren't used anywhere yet, and I've opened a separate issue for making sure the correct libraries are installed.
