### PR TITLE
Remove Account.id

### DIFF
--- a/peacecorps/peacecorps/fixtures/global-general.yaml
+++ b/peacecorps/peacecorps/fixtures/global-general.yaml
@@ -1,11 +1,11 @@
-- fields: {category: oth, code: PCF-GEN, community_contribution: null, current: 0,
+- fields: {category: oth, community_contribution: null, current: 0,
     goal: null, name: General}
   model: peacecorps.account
-  pk: 1
-- fields: {category: oth, code: SPF-GBL, community_contribution: null, current: 0,
+  pk: PCF-GEN
+- fields: {category: oth, community_contribution: null, current: 0,
     goal: null, name: Global}
   model: peacecorps.account
-  pk: 2
+  pk: SPF-GBL
 - fields:
     account: PCF-GEN
     call: Give Now

--- a/peacecorps/peacecorps/fixtures/issues.yaml
+++ b/peacecorps/peacecorps/fixtures/issues.yaml
@@ -1,47 +1,47 @@
-- fields: {category: sec, code: SPF-AGG, community_contribution: null, current: 0,
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Agriculture Fund}
   model: peacecorps.account
-  pk: 61
-- fields: {category: sec, code: SPF-BUS, community_contribution: null, current: 0,
+  pk: SPF-AGG
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Business Development Fund}
   model: peacecorps.account
-  pk: 62
-- fields: {category: sec, code: SPF-WAT, community_contribution: null, current: 0,
+  pk: SPF-BUS
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Drinking Water and Sanitation Fund}
   model: peacecorps.account
-  pk: 63
-- fields: {category: sec, code: SPF-EDU, community_contribution: null, current: 0,
+  pk: SPF-WAT
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Education Fund}
   model: peacecorps.account
-  pk: 64
-- fields: {category: sec, code: SPF-ENV, community_contribution: null, current: 0,
+  pk: SPF-EDU
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Environment Fund}
   model: peacecorps.account
-  pk: 65
-- fields: {category: sec, code: SPF-HHA, community_contribution: null, current: 0,
+  pk: SPF-ENV
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Health and HIV/AIDS Fund}
   model: peacecorps.account
-  pk: 66
-- fields: {category: sec, code: SPF-ICT, community_contribution: null, current: 0,
+  pk: SPF-HHA
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Information & Communication Technology Fund}
   model: peacecorps.account
-  pk: 67
-- fields: {category: sec, code: SPF-YTH, community_contribution: null, current: 0,
+  pk: SPF-ICT
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Youth Fund}
   model: peacecorps.account
-  pk: 68
-- fields: {category: sec, code: SPF-MDF, community_contribution: null, current: 0,
+  pk: SPF-YTH
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Municipal Development Fund}
   model: peacecorps.account
-  pk: 69
-- fields: {category: sec, code: SPF-GND, community_contribution: null, current: 0,
+  pk: SPF-MDF
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Ruppe Gender Development Fund}
   model: peacecorps.account
-  pk: 70
-- fields: {category: sec, code: SPF-MLR, community_contribution: null, current: 0,
+  pk: SPF-GND
+- fields: {category: sec, community_contribution: null, current: 0,
     goal: null, name: Stomping Out Malaria in Africa}
   model: peacecorps.account
-  pk: 71
+  pk: SPF-MLR
 - fields:
     account: SPF-AGG
     call: null

--- a/peacecorps/peacecorps/migrations/0053_remove_account_id.py
+++ b/peacecorps/peacecorps/migrations/0053_remove_account_id.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def make_code_cp(model_name, field_name):
+    """Copy over accounts from an int id to a str id"""
+    def inner(apps, schema_editor):
+        for model in apps.get_model("peacecorps", model_name).objects.all():
+            code = getattr(model, field_name).code
+            setattr(model, field_name + "_tmp", code)
+            model.save()
+    return inner
+
+
+def make_rev_code_cp(model_name, field_name):
+    """Copy over accounts from an str int id to an int id. As we're only
+    dealing with varchars, we'll need to do lookups"""
+    def inner(apps, schema_editor):
+        for model in apps.get_model("peacecorps", model_name).objects.all():
+            code = getattr(model, field_name + "_tmp")
+            setattr(model, field_name,
+                    apps.get_model("peacecorps", "account").objects.get(
+                        code=code))
+            model.save()
+    return inner
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0052_auto_20141218_2233'),
+    ]
+
+    operations = [
+        # Add temporary, nullable fields
+        migrations.AddField(
+            model_name='donation',
+            name='account_tmp',
+            field=models.CharField(null=True, blank=True, max_length=25),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='donorinfo',
+            name='account_tmp',
+            field=models.CharField(null=True, blank=True, max_length=25),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='overflow_tmp',
+            field=models.CharField(null=True, blank=True, max_length=25),
+            preserve_default=True,
+        ),
+        # Copy over data
+        migrations.RunPython(make_code_cp('Donation', 'account'),
+                             make_rev_code_cp('Donation', 'account')),
+        migrations.RunPython(make_code_cp('DonorInfo', 'account'),
+                             make_rev_code_cp('DonorInfo', 'account')),
+        migrations.RunPython(make_code_cp('Project', 'overflow'),
+                             make_rev_code_cp('Project', 'overflow')),
+        # Remove old fields
+        migrations.RemoveField(model_name='donation', name='account'),
+        migrations.RemoveField(model_name='donorinfo', name='account'),
+        migrations.RemoveField(model_name='project', name='overflow'),
+        # Rename fields
+        migrations.RenameField(model_name='donation', old_name='account_tmp',
+                               new_name='account'),
+        migrations.RenameField(model_name='donorinfo', old_name='account_tmp',
+                               new_name='account'),
+        migrations.RenameField(model_name='project', old_name='overflow_tmp',
+                               new_name='overflow'),
+        # Convert all other account-referencing fields to charfields (removing
+        # fks)
+        migrations.AlterField(
+            model_name='featuredcampaign',
+            name='campaign',
+            field=models.CharField(max_length=25),
+        ),
+        migrations.AlterField(
+            model_name='featuredprojectfrontpage',
+            name='project',
+            field=models.CharField(max_length=25),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='account',
+            field=models.CharField(max_length=25, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='account',
+            field=models.CharField(max_length=25),
+        ),
+        # Remove the id field on account
+        migrations.RemoveField(
+            model_name='account',
+            name='id',
+        ),
+        migrations.AlterField(
+            model_name='account',
+            name='code',
+            field=models.CharField(max_length=25, serialize=False,
+                                   primary_key=True),
+        ),
+        # Update all references
+        migrations.AlterField(
+            model_name='campaign',
+            name='account',
+            field=models.ForeignKey(null=True, blank=True, unique=True,
+                                    to='peacecorps.Account'),
+        ),
+        migrations.AlterField(
+            model_name='donation',
+            name='account',
+            field=models.ForeignKey(
+                related_name='donations', to='peacecorps.Account'),
+        ),
+        migrations.AlterField(
+            model_name='donorinfo',
+            name='account',
+            field=models.ForeignKey(
+                related_name='donorinfos', to='peacecorps.Account'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='account',
+            field=models.ForeignKey(unique=True, to='peacecorps.Account'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='overflow',
+            field=models.ForeignKey(
+                null=True, blank=True, related_name='overflow',
+                help_text=('Select another fund to which users will be '
+                           + 'directed to\n                    donate if '
+                           + 'the project is already funded.'),
+                to='peacecorps.Account'),
+        ),
+        migrations.AlterField(
+            model_name='featuredcampaign',
+            name='campaign',
+            field=models.ForeignKey(to='peacecorps.Campaign',
+                                    to_field='account'),
+        ),
+        migrations.AlterField(
+            model_name='featuredprojectfrontpage',
+            name='project',
+            field=models.ForeignKey(to='peacecorps.Project',
+                                    to_field='account'),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -43,7 +43,7 @@ class Account(models.Model):
     )
 
     name = models.CharField(max_length=120, unique=True)
-    code = models.CharField(max_length=25, unique=True)
+    code = models.CharField(max_length=25, primary_key=True)
     current = models.IntegerField(default=0)
     goal = models.IntegerField(blank=True, null=True)
     community_contribution = models.IntegerField(blank=True, null=True)
@@ -108,8 +108,7 @@ class Campaign(models.Model):
     )
 
     name = models.CharField(max_length=120)
-    account = models.ForeignKey(
-        'Account', to_field='code', unique=True, blank=True, null=True)
+    account = models.ForeignKey('Account', unique=True, blank=True, null=True)
     campaigntype = models.CharField(
         max_length=10, choices=CAMPAIGNTYPE_CHOICES)
     icon = models.ForeignKey(
@@ -133,7 +132,7 @@ class Campaign(models.Model):
         'Country', related_name="campaign", blank=True, null=True, unique=True)
 
     def __str__(self):
-        return '%s: %s' % (self.account_id, self.name )
+        return '%s: %s' % (self.account_id, self.name)
 
     def save(self, *args, **kwargs):
         if not self.slug:
@@ -238,9 +237,9 @@ class Project(models.Model):
         help_text="A large landscape image for use in banners, headers, etc")
     media = models.ManyToManyField(
         'Media', related_name="projects", blank=True, null=True)
-    account = models.ForeignKey('Account', to_field='code', unique=True)
+    account = models.ForeignKey('Account', unique=True)
     overflow = models.ForeignKey(
-        'Account', related_name="overflow", blank=True, null=True,
+        'Account', blank=True, null=True, related_name='overflow',
         help_text="""Select another fund to which users will be directed to
                     donate if the project is already funded.""")
     volunteername = models.CharField(max_length=100)

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -171,7 +171,7 @@ class SyncAccountingTests(TestCase):
         self.assertEqual(account.name, 'Some Proj')
         self.assertEqual(account.code, '121-212')
         self.assertEqual(account.category, Account.PROJECT)
-        self.assertIsNone(account.pk)
+        self.assertEqual(0, len(Account.objects.filter(pk=account.pk)))
 
     @patch('peacecorps.management.commands.sync_accounting.create_campaign')
     def test_create_account_campaign(self, create):
@@ -185,7 +185,7 @@ class SyncAccountingTests(TestCase):
         self.assertEqual(account.name, 'Argentina Fund')
         self.assertEqual(account.code, '789-CFD')
         self.assertEqual(account.category, Account.COUNTRY)
-        self.assertIsNone(account.pk)
+        self.assertEqual(0, len(Account.objects.filter(pk=account.pk)))
 
     @patch('peacecorps.management.commands.sync_accounting.Campaign')
     def test_create_account_double(self, Campaign):


### PR DESCRIPTION
Right now, Account's primary key is an integer. This is generally fine, but will make fixtures difficult to integrate.

This migrates the db so that Account's primary key is its code. In the future, we may want to similarly modify `Campaign` and `Project`'s pks.
