### PR TITLE
Account for projects with no volunteer photo

### DIFF
--- a/peacecorps/peacecorps/templates/donations/base.jinja
+++ b/peacecorps/peacecorps/templates/donations/base.jinja
@@ -13,7 +13,7 @@
 <body>
 <nav class="banner banner--dark_transparent banner--no_line"
   style="position: absolute; top: 0; left: 0;">
-  <a href="http://peaceocorps.gov" class="t-single_nav t--white">
+  <a href="http://peacecorps.gov" class="t-single_nav t--white">
     <span class="t-title--4">
       Back to Peacecorps.gov home
     </span>

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -1,5 +1,5 @@
 {% extends "donations/base.jinja" %}
-{% from "donations/includes/macros.jinja" import url_or %}
+{% from "donations/includes/macros.jinja" import url_or, volunteer_photo %}
 
 {% block title %}Peace Corps{% endblock %}
 {% block header %}Peace Corps{% endblock %}
@@ -225,11 +225,9 @@
       <div class="mask mask--oval mask--gray-1 mask--bordered
            u-clearfix section__content--no_space_r u-pullr"
            style="width: 5em; height: 5em;">
-        <img class=""
-          class="mask__content"
-          style="width: 100%;"
-          src="{{ project.volunteerpicture }}"
-          alt="{{ project.volunteername }}" />
+        <div class="t-body--xsm">
+          {{ volunteer_photo(project) }}
+        </div>
       </div>
     </aside>
     <header class="grid--80 section__content--contain--sm grid__last">
@@ -250,9 +248,7 @@
         <div class="mask mask--oval mask--gray-1 mask--bordered
              u-clearfix u-h_center--block l-bm--1 column__element"
              style="width: 12em; height: 12em;">
-          <img class="mask__content" style="width: 100%;"
-               src="{{ project.volunteerpicture.url }}"
-               alt="{{ project.volunteername }}" />
+          {{ volunteer_photo(project) }}
         </div>
         <div class="u-h_center--block column__element
               section__content--no_space_r">

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -225,9 +225,13 @@
       <div class="mask mask--oval mask--gray-1 mask--bordered
            u-clearfix section__content--no_space_r u-pullr"
            style="width: 5em; height: 5em;">
-        <div class="t-body--xsm">
+        {% if project.volunteerpicture %}
           {{ volunteer_photo(project) }}
-        </div>
+        {% else %}
+          <img src="{{ static("peacecorps/img/countries/"
+                      + project.country.code.lower() + ".svg") }}"
+               class="mask__content" style="width: 100%;" />
+        {% endif %}
       </div>
     </aside>
     <header class="grid--80 section__content--contain--sm grid__last">

--- a/peacecorps/peacecorps/templates/donations/includes/macros.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/macros.jinja
@@ -5,3 +5,18 @@
     {{ default }}
   {%- endif %}
 {%- endmacro %}
+
+{% macro volunteer_photo(project) %}
+  {% if project.volunteerpicture %}
+    <img class="mask__content"
+         style="width: 100%;"
+         src="{{ project.volunteerpicture.url }}"
+         alt="{{ project.volunteername }}" />
+  {% else %}
+    <div class="mask__content u-align_c"
+         style="width: 100%;">
+      {{ project.volunteername }}<br />
+      volunteer from {{project.volunteerhomestate}}
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/peacecorps/peacecorps/templates/donations/includes/project-top.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/project-top.jinja
@@ -1,3 +1,5 @@
+{% from "donations/includes/macros.jinja" import volunteer_photo %}
+
 <div class="full_bg full_bg--lg" style="height: 37em;
     background-image: url('{{ project.featured_image.url or '' }}');
   ">
@@ -13,14 +15,14 @@
 
     <div class="inline_grid l-bm--3 u-clearfix">
       <section class="u-align_c inline_grid--15">
-          <div class="mask mask--oval mask--bordered u-h_center--block">
-            <img class="mask__content"
-                 src="{{project.volunteerpicture.url}}"
-                 alt="{{project.volunteerpicture.description}}">
-          </div>
-        <span class="t-body--sm"><strong>{{project.volunteername}}</strong><br>
-          volunteer from <strong>{{project.volunteerhomestate}}</strong>
-        </span>
+        <div class="mask mask--oval mask--bordered u-h_center--block">
+          {{ volunteer_photo(project) }}
+        </div>
+        {% if project.volunteerpicture %}
+          <span class="t-body--sm"><strong>{{project.volunteername}}</strong><br>
+            volunteer from <strong>{{project.volunteerhomestate}}</strong>
+          </span>
+        {% endif %}
       </section>
       <section class="u-align_c inline_grid--15">
         <div class="mask mask--oval mask--bordered u-h_center--block map">

--- a/peacecorps/peacecorps/templates/donations/project_success.jinja
+++ b/peacecorps/peacecorps/templates/donations/project_success.jinja
@@ -1,4 +1,5 @@
 {% extends "donations/base.jinja" %}
+{% from "donations/includes/macros.jinja" import volunteer_photo %}
 
 {% block title %}Peace Corps | Thank You{% endblock %}
 {% block header %}Peace Corps | Thank You{% endblock %}
@@ -41,14 +42,14 @@
       <h3>{{project.title}}</h2>
       <section class="blurb">
         <section class="u-align_c">
-            <div class="mask mask--oval mask--bordered u-h_center--block">
-              <img class="mask__content"
-                   src="{{project.volunteerpicture.url}}"
-                   alt="{{project.volunteerpicture.description}}">
-            </div>
-          <span class="t-body--sm"><strong>{{project.volunteername}}</strong><br>
-            volunteer from <strong>{{project.volunteerhomestate}}</strong>
-          </span>
+          <div class="mask mask--oval mask--bordered u-h_center--block">
+            {{ volunteer_photo(project) }}
+          </div>
+          {% if project.volunteerpicture %}
+            <span class="t-body--sm"><strong>{{project.volunteername}}</strong><br>
+              volunteer from <strong>{{project.volunteerhomestate}}</strong>
+            </span>
+          {% endif %}
         </section>
         <section class="u-align_c">
           <div class="mask mask--oval mask--bordered u-h_center--block map">


### PR DESCRIPTION
- Add a new macro for volunteer photos
- This macro shows the image url if present, and a div with the name/state if not
- Make the text smaller when in the volunteer selection screen
- Typo in peace corps url

![screen shot 2014-12-24 at 10 40 21 am](https://cloud.githubusercontent.com/assets/326918/5549468/546825a8-8b59-11e4-9f41-de441bf131d8.png)
![screen shot 2014-12-24 at 12 43 36 am](https://cloud.githubusercontent.com/assets/326918/5546058/01cdf546-8b06-11e4-9a8e-46b6673c9635.png)
![screen shot 2014-12-24 at 12 43 57 am](https://cloud.githubusercontent.com/assets/326918/5546057/01cd7c6a-8b06-11e4-8c44-0401cbb75b57.png)
