### PR TITLE
Fixes to goals/totals/etc.

### DIFF
--- a/peacecorps/peacecorps/api.py
+++ b/peacecorps/peacecorps/api.py
@@ -1,9 +1,9 @@
-from django.conf import settings
 from restless.views import Endpoint
 
 from peacecorps.models import Account
 
+
 class GetAccountPercent(Endpoint):
     def get(self, request, slug):
-        percent = Account.objects.get(code=slug).percent_funded()
+        percent = Account.objects.get(code=slug).percent_raised()
         return {'percent': percent}

--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 from django.conf import settings
 from django.core.urlresolvers import reverse
 
-from peacecorps.models import Account, DonorInfo, humanize_amount
+from peacecorps.models import Account, DonorInfo
+from peacecorps.templatetags.humanize_cents import humanize_cents
 
 
 def add_subelements(parent, data, elements):
@@ -21,7 +22,7 @@ def generate_agency_memo(data):
     memo += '(' + data.get('comments', '').strip() + ')'
     memo += '(' + data.get('phone_number', '').strip() + ')'
 
-    amount = humanize_amount(data['payment_amount'])
+    amount = humanize_cents(data['payment_amount'])
     memo += '(%s, %s)' % (data['project_code'], amount)
 
     if data.get('information_consent'):

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -271,30 +271,28 @@
       <div class="rectangular_progress
                   rectangular_progress--mini
                   rectangular_progress--secondary">
-        {% set percent_completed = project.account.percent_funded() %}
-        {% set amount_completed = (project.account.community_contribution +
-            project.account.current) %}
+        {% set percent_raised = project.account.percent_raised() %}
         <div class="rectangular_progress__bar">
           <div class="rectangular_progress__filled"
-              style="width: {{ percent_completed }}%;">
+              style="width: {{ percent_raised }}%;">
           </div>
         </div>
-        <span style="left: {{ percent_completed }}%;"
+        <span style="left: {{ percent_raised }}%;"
             class="rectangular_progress__line
                   rectangular_progress__line--bottom">
         </span>
         <span class="rectangular_progress__point
                      rectangular_progress__point--bottom
                      t-title--4"
-            style="left: {{ percent_completed }}%;">
-          {{ humanize_amount(amount_completed) }} raised
+            style="left: {{ percent_raised }}%;">
+          {{ humanize_cents(project.account.total_raised()) }} raised
         </span>
 
         <span class="rectangular_progress__point
                      u-align_r t-heading--4 t--secondary" style="right: 0;">
-           {{ humanize_amount(project.account.remaining()) }} needed
+           {{ humanize_cents(project.account.remaining()) }} needed
           <br><strong class="t-title--5 t--gray--2">
-            to reach {{ humanize_amount(project.account.goal) }} goal
+            to reach {{ humanize_cents(project.account.total_cost()) }} goal
           </strong><br>
         </span>
         <span style="left: 100%;"

--- a/peacecorps/peacecorps/templates/donations/donate_project.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_project.jinja
@@ -39,7 +39,7 @@
             t-title--4" style="right: 0;">
           goal
           <br><strong class="t-title--2 t--secondary">
-            {{humanize_cents(project.account.goal)}}
+            {{humanize_cents(project.account.total_cost())}}
           </strong><br>
         </span>
         <span style="left: 100%;"

--- a/peacecorps/peacecorps/templates/donations/donate_project.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_project.jinja
@@ -20,8 +20,8 @@
       <h4 class="t-title--4 t--gray--2">Help fund this project</h4>
       <h3 class="t-heading--3 t--gray--2">
         Give to {{project.title}}</h3>
-      {% set percent_completed = project.account.percent_funded() %}
-      {% set percent_community = project.account.percent_community_funded() %}
+      {% set percent_raised = project.account.percent_raised() %}
+      {% set percent_community = project.account.percent_community() %}
       <div class="rectangular_progress
           t--secondary
           rectangular_progress--secondary">
@@ -29,7 +29,7 @@
             style="left:{{percent_community}}%;">
           community contributions<br>
           <strong>
-            {{humanize_amount(project.account.community_contribution)}}
+            {{humanize_cents(project.account.community_contribution)}}
           </strong>
         </span>
         <span style="left: {{percent_community}}%;"
@@ -39,7 +39,7 @@
             t-title--4" style="right: 0;">
           goal
           <br><strong class="t-title--2 t--secondary">
-            {{humanize_amount(project.account.goal)}}
+            {{humanize_cents(project.account.goal)}}
           </strong><br>
         </span>
         <span style="left: 100%;"
@@ -48,19 +48,19 @@
         </span>
         <div class="rectangular_progress__bar">
           <div class="rectangular_progress__filled"
-              style="width: {{percent_completed}}%;">
+              style="width: {{percent_raised}}%;">
           </div>
         </div>
-        <span style="left: {{percent_completed}}%;"
+        <span style="left: {{percent_raised}}%;"
             class="rectangular_progress__line
                   rectangular_progress__line--bottom">
         </span>
         <span class="rectangular_progress__point
                      rectangular_progress__point--bottom
                      t-title--4"
-            style="left: {{percent_completed}}%;">
+            style="left: {{percent_raised}}%;">
           <strong>
-            {{humanize_amount(project.account.current)}}
+            {{humanize_cents(project.account.total_raised())}}
           </strong><br>
           total raised
         </span>

--- a/peacecorps/peacecorps/templates/donations/donation_payment.jinja
+++ b/peacecorps/peacecorps/templates/donations/donation_payment.jinja
@@ -8,7 +8,7 @@
 {% block content %}
   <section class="blurb blurb--sm">
     <p> Project Code: {{project_code }} </p>
-    <p> Amount: {{amount}} </p>
+    <p> Amount: {{humanize_cents(amount)}} </p>
   </section>
 
   <section class="section full_banner full_banner--neutral">

--- a/peacecorps/peacecorps/templates/donations/includes/amount-form.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/amount-form.jinja
@@ -4,7 +4,7 @@
     <fieldset class="bubble_form">
       <legend class="t-title--3 t-nom">Give to this project</legend>
       {% if IS_PROJECT %}
-        <span>{{ humanize_amount(account.remaining()) }}
+        <span>{{ humanize_cents(account.remaining()) }}
           to meet goal</span>
       {% endif %}
       {{ donate_form.payment_amount.errors }}

--- a/peacecorps/peacecorps/templates/donations/includes/project-top.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/project-top.jinja
@@ -33,13 +33,13 @@
           </span>
       </section>
       <section class="u-align_c inline_grid--15">
-        {% set percent_completed = project.account.percent_funded() %}
+        {% set percent_raised = project.account.percent_raised() %}
         <div class="radialProgress u-h_center--block"
-          {% if percent_completed < 50 %}
-            {% set deg = 90 + (3.6 * percent_completed) %}
+          {% if percent_raised < 50 %}
+            {% set deg = 90 + (3.6 * percent_raised) %}
           style="background-image: linear-gradient(90deg, #F2EFE8 50%, transparent 50%, transparent), linear-gradient({{ deg }}deg, #A12122 50%, #F2EFE8 50%, #F2EFE8);"
           {% else %}
-            {% set deg = -90 + (3.6 * (percent_completed - 50)) %}
+            {% set deg = -90 + (3.6 * (percent_raised - 50)) %}
           style="background-image: linear-gradient({{ deg }}deg, #A12122 50%, transparent 50%, transparent), linear-gradient(270deg, #A12122 50%, #F2EFE8 50%, #F2EFE8);"
           {% endif %}
         >
@@ -47,8 +47,8 @@
           </div>
         </div>
         <span class="t-body--sm">
-          {{ project.account.remaining() }} needed to reach
-          {{ project.account.goal }} goal
+          {{ humanize_cents(project.account.remaining()) }} needed to reach
+          {{ humanize_cents(project.account.total_cost()) }} goal
         </span>
       </section>
     </div>

--- a/peacecorps/peacecorps/templatetags/humanize_cents.py
+++ b/peacecorps/peacecorps/templatetags/humanize_cents.py
@@ -1,0 +1,8 @@
+"""Convert an integer quantity of cents into a dollar amount, separated by
+commas"""
+from django_jinja import library
+
+
+@library.global_function
+def humanize_cents(amount):
+    return "${:,.2f}".format(amount/100.0)

--- a/peacecorps/peacecorps/tests/test_models.py
+++ b/peacecorps/peacecorps/tests/test_models.py
@@ -5,14 +5,6 @@ from django.test import TestCase
 from peacecorps import models
 
 
-class HumanizeTest(TestCase):
-    def test_humanize_amount(self):
-        self.assertEqual('$0.00', models.humanize_amount(0))
-        self.assertEqual('$0.12', models.humanize_amount(12))
-        self.assertEqual('$1.23', models.humanize_amount(123))
-        self.assertEqual('$12,345,678.90', models.humanize_amount(1234567890))
-
-
 class AccountTest(TestCase):
     def test_funded(self):
         account = models.Account()
@@ -26,7 +18,7 @@ class AccountTest(TestCase):
         account.goal = 99
         self.assertTrue(account.funded())
 
-    def test_track_total(self):
+    def test_track_total_donated(self):
         """Use fake data to verify that account totals are being
         kept up-to-date"""
         def makedonation(acct, amount):
@@ -41,25 +33,25 @@ class AccountTest(TestCase):
         makedonation(acc1, 100)
         makedonation(acc1, 1)
 
-        self.assertEqual(326, acc1.total())
+        self.assertEqual(326, acc1.total_donated())
 
-    def test_percent_funded(self):
+    def test_percent_raised(self):
         account = models.Account()
         account.donations = []
         account.current = 30
         account.community_contribution = 10
         account.goal = 70
-        self.assertEqual(50, account.percent_funded())
+        self.assertEqual(50, account.percent_raised())  # 40/80
         account.current += 20
-        self.assertEqual(75, account.percent_funded())
+        self.assertEqual(75, account.percent_raised())  # 60/80
 
-    def test_community_funded(self):
+    def test_percent_community(self):
         account = models.Account()
         account.community_contribution = 80
         account.goal = 80
-        self.assertEqual(50, account.percent_community_funded())
+        self.assertEqual(50, account.percent_community())   # 80/160
         account.community_contribution = 100
-        self.assertEqual(55.56, account.percent_community_funded())
+        self.assertEqual(55.56, account.percent_community())    # 100/180
 
 
 class ProjectTests(TestCase):

--- a/peacecorps/peacecorps/tests/test_templatetags.py
+++ b/peacecorps/peacecorps/tests/test_templatetags.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from peacecorps.templatetags.humanize_cents import humanize_cents
+
+
+class HumanizeTest(TestCase):
+    def test_humanize_cents(self):
+        """ The humanize_cents function converts an amount in cents into
+        something that's human readable. """
+        self.assertEqual('$0.00', humanize_cents(0))
+        self.assertEqual('$0.12', humanize_cents(12))
+        self.assertEqual('$1.23', humanize_cents(123))
+        self.assertEqual('$12,345,678.90', humanize_cents(1234567890))

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 
 from peacecorps.models import Account, Campaign, Country, FAQ, Media, Project
-from peacecorps.views import humanize_amount
 
 
 class DonationsTests(TestCase):
@@ -81,12 +80,6 @@ class DonationsTests(TestCase):
         #   Also verify that the http host has been added
         donorinfo = account.donorinfos.get()
         self.assertTrue('://example.com' in donorinfo.xml)
-
-    def test_humanize_amount(self):
-        """ The humanize_amount function converts an amount in cents into
-        something that's human readable. """
-        self.assertEqual(humanize_amount(1520), '$15.20')
-        self.assertEqual(humanize_amount(0), '$0.00')
 
     def test_bad_request_donations(self):
         """ The donation information page should 400 if donation amount and

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -10,7 +10,7 @@ from django.views.decorators.csrf import csrf_exempt
 from peacecorps.forms import DonationAmountForm, DonationPaymentForm
 from peacecorps.models import (
     Account, Campaign, FAQ, FeaturedCampaign, FeaturedProjectFrontPage,
-    Issue, humanize_amount, Project, Vignette)
+    Issue, Project, Vignette)
 from peacecorps.payxml import convert_to_paygov
 
 
@@ -32,8 +32,6 @@ def donation_payment(request):
     if not account:
         return HttpResponseBadRequest('Invalid project')
 
-    readable_amount = humanize_amount(amount)
-
     if request.method == 'POST':
         form = DonationPaymentForm(request.POST)
 
@@ -50,7 +48,7 @@ def donation_payment(request):
         request, 'donations/donation_payment.jinja',
         {
             'form': form,
-            'amount': readable_amount,
+            'amount': amount,
             'project_code': project_code
         })
 
@@ -99,7 +97,6 @@ def donate_landing(request):
                 campaigntype=Campaign.SECTOR).order_by('name'),
             'featuredprojects': featuredprojects,
             'projects': projects,
-            'humanize_amount': humanize_amount,
         })
 
 
@@ -133,7 +130,6 @@ def donate_project(request, slug):
             'project': project,
             'account': project.account,
             'donate_form': form,
-            'humanize_amount': humanize_amount,
             "IS_PROJECT": project.account.category == Account.PROJECT,
         })
 
@@ -155,7 +151,6 @@ def donate_projects_funds(request):
             'countries': countries,
             'issues': issues,
             'projects': projects,
-            'humanize_amount': humanize_amount,
         })
 
 
@@ -200,7 +195,6 @@ def fund_detail(request, slug):
             'campaign': campaign,
             'account': campaign.account,
             'donate_form': form,
-            'humanize_amount': humanize_amount,
             "IS_PROJECT": campaign.account.category == Account.PROJECT,
         })
 


### PR DESCRIPTION
For the most part, this is an update to rename methods to match their updated designs. In the process, the correct values replaced some incorrect ones.

Specifics:
- `total_donated` is the amount (in cents) from donations, including real-time. This does not include community contributions
- `total_raised` is the amount (in cents) from donations and community contributions
- `total_cost` is the amount (in cents) of the fund raising goal + the community contributions (i.e. the sticker price on whatever is being bought/built)
- `percent_xxx` is the amount as a percentage of the total cost
- moved `humanize_amount` into a template tag; renamed to `humanize_cents`

Before/Afters:
![screen shot 2014-12-26 at 11 58 58 am](https://cloud.githubusercontent.com/assets/326918/5558683/9ded0f06-8cf6-11e4-903c-0c5e63cf38f7.png)
## ![screen shot 2014-12-26 at 11 59 22 am](https://cloud.githubusercontent.com/assets/326918/5558684/a9de71e2-8cf6-11e4-9eb3-8ab7c6d617bc.png)

![screen shot 2014-12-26 at 12 00 01 pm](https://cloud.githubusercontent.com/assets/326918/5558687/c9250b92-8cf6-11e4-8ed9-3445850900bd.png)
## ![screen shot 2014-12-26 at 12 00 11 pm](https://cloud.githubusercontent.com/assets/326918/5558688/c92852a2-8cf6-11e4-98e1-465bd7831347.png)

![screen shot 2014-12-26 at 12 00 41 pm](https://cloud.githubusercontent.com/assets/326918/5558693/e2201204-8cf6-11e4-9548-dbef16a4ff6e.png)
![screen shot 2014-12-26 at 12 02 46 pm](https://cloud.githubusercontent.com/assets/326918/5558700/2a2e6334-8cf7-11e4-943f-8b35d550bc03.png)
