### PR TITLE
Must download the python3 version of memcached lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,6 @@ psycopg2==2.5.3
 boto
 python-logstash
 django-admin-sortable2
+python3-memcached
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
 -e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages


### PR DESCRIPTION
Currently no caching on demo servers because this lib isn't present.
