### PR TITLE
Use elasticache-specific lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - $HOME/.pip-cache/
 install:
+    - sudo apt-get install libmemcached-dev
     - pip install -r requirements.txt --download-cache $HOME/.pip-cache --use-mirrors
     - pip install -r requirements-dev.txt --download-cache $HOME/.pip-cache --use-mirrors
 script:

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ general:
 
 dependencies:
     pre:
+        - sudo apt-get install libmemcached-dev
         - pip install -r ../requirements.txt
         - pip install -r ../requirements-dev.txt
         - npm install:

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -87,11 +87,13 @@ CACHES = {
     },
     'shortterm': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        'TIMEOUT': 60*5    # 5 minutes
+        'TIMEOUT': 60*5,    # 5 minutes
+        'KEY_PREFIX': 'shortterm',
     },
     'midterm': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        'TIMEOUT': 60*60    # 1 hour
+        'TIMEOUT': 60*60,    # 1 hour
+        'KEY_PREFIX': 'midterm',
     }
 }
 

--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -24,7 +24,7 @@ MIDDLEWARE_CLASSES = (
 
 MEMCACHED_URL = os.environ.get('MEMCACHED_URL', '')
 if MEMCACHED_URL:
-    _backend = 'django.core.cache.backends.memcached.MemcachedCache'
+    _backend = 'django_elasticache.memcached.ElastiCache'
     CACHES['shortterm']['BACKEND'] = _backend
     CACHES['shortterm']['LOCATION'] = MEMCACHED_URL
     CACHES['midterm']['BACKEND'] = _backend

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ psycopg2==2.5.3
 boto
 python-logstash
 django-admin-sortable2
-python3-memcached
+django-elasticache
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
 -e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages


### PR DESCRIPTION
The memcached lib does not support autodiscovery, so each memcached instance must be hard coded. Instead, use an elasticache-aware library, which should perform the auto-discovery for us.

@annalee @msecret - note that this python library has a c requirement. The next time you `pip install -r`, you'll want to first `apt-get install libmemcached-dev`. This is already part of the deployment scripts.
