### PR TITLE
Use updated version of this lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ psycopg2==2.5.3
 boto
 python-logstash
 django-admin-sortable2
-django-elasticache
+# The pypi version hasn't caught up yet. When possible, switch to django-elasticache>=0.0.3
+-e git://github.com/gusdan/django-elasticache.git#egg=django-elasticache
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
 -e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages


### PR DESCRIPTION
The version of django-elasticache in pypi (0.0.2) did not have Python3 support. We added such support so the version was bumped to 0.0.3. This hasn't made its way into pypi yet, so we'll use the github code.
