### PR TITLE
Check amount on the second step of the donation form

### DIFF
--- a/peacecorps/peacecorps/forms.py
+++ b/peacecorps/peacecorps/forms.py
@@ -95,9 +95,6 @@ class DonationPaymentForm(forms.Form):
         label='Make my contact info available to the volunteer',
         required=False, initial=True)
 
-    payment_amount = forms.IntegerField(widget=forms.HiddenInput())
-    project_code = forms.CharField(max_length=40, widget=forms.HiddenInput())
-
     def required_when(self, guard_field, guard_value, check_field, field_name):
         """Raises a validation error when both the field with name guard_field
         is equal to guard_value and the field with name check_field is
@@ -160,7 +157,10 @@ class DonationAmountForm(forms.Form):
     def __init__(self, *args, **kwargs):
         """Note that project_max, if present, is in cents while payment_amount
         is in dollars"""
-        self.project_max = kwargs.pop('project_max', None)
+        self.project_max = None
+        account = kwargs.pop('account', None)
+        if account and account.goal:
+            self.project_max = account.remaining()
         super(DonationAmountForm, self).__init__(*args, **kwargs)
 
     def clean_payment_amount(self):

--- a/peacecorps/peacecorps/templates/donations/checkout_base.jinja
+++ b/peacecorps/peacecorps/templates/donations/checkout_base.jinja
@@ -17,7 +17,7 @@
       <div class="u-align_l inset--sm t--gray--2">
         <h3 class="t-heading--stylized">You are donating</h3><br>
         <h1 class="t-heading--stylized t--secondary">
-          {{ humanize_cents(amount) }}</h1>
+          {{ humanize_cents(payment_amount) }}</h1>
         <h4 class="t-heading--stylized">to</h4><br>
         <h3 class="t-heading--stylized">
           <strong>{{ project.title or account_name }}</strong></h3>

--- a/peacecorps/peacecorps/tests/test_forms.py
+++ b/peacecorps/peacecorps/tests/test_forms.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from django.test import TestCase
 
-from peacecorps.models import Country
+from peacecorps.models import Account, Country
 from peacecorps.forms import DonationAmountForm, DonationPaymentForm
 
 
@@ -160,11 +160,13 @@ class DonationAmountTests(TestCase):
     def test_custom_per_project_upper_limit(self):
         """Error if trying to donate more than a project needs"""
         data = {'presets': 'preset-50'}
-        form = DonationAmountForm(data=data, project_max=4000)
+        account = Account(goal=8000, current=3001)
+        form = DonationAmountForm(data=data, account=account)
         self.assertFalse(form.is_valid())
         errors = form.errors.as_data()
         self.assertEqual('max_value', errors['payment_amount'][0].code)
-        self.assertTrue('$40.00' in errors['payment_amount'][0].message)
+        self.assertTrue('$49.99' in errors['payment_amount'][0].message)
 
-        form = DonationAmountForm(data=data, project_max=50000)
+        account.current = 3000
+        form = DonationAmountForm(data=data, account=account)
         self.assertTrue(form.is_valid())

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -215,6 +215,28 @@ class DonatePagesTests(TestCase):
         self.assertTrue("5000" in response['Location'])
         self.assertTrue('peace-corps' in response['Location'])
 
+    def test_project_fund_prepopulation(self):
+        """Prepopulate the form with amount from GET var"""
+        response = self.client.get(
+            reverse('donate project', kwargs={'slug': 'brick-oven-bakery'}),
+            {'payment_amount': '12.34'})
+        self.assertContains(response, '12.34')
+        response = self.client.get(
+            reverse('donate project', kwargs={'slug': 'brick-oven-bakery'}),
+            {'payment_amount': '.95'})
+        self.assertContains(response, '.95')
+        self.assertContains(response, 'error')
+
+        response = self.client.get(
+            reverse('donate campaign', kwargs={'slug': 'peace-corps'}),
+            {'payment_amount': '12.34'})
+        self.assertContains(response, '12.34')
+        response = self.client.get(
+            reverse('donate campaign', kwargs={'slug': 'peace-corps'}),
+            {'payment_amount': '10000'})
+        self.assertContains(response, '10000')
+        self.assertContains(response, 'error')
+
     def test_project_success_failure(self):
         response = self.client.get(
             reverse('project success', kwargs={'slug': 'nonproj'}))

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -12,7 +12,8 @@ class DonationsTests(TestCase):
 
     def setUp(self):
         self.proj_acc = Account.objects.create(
-            name='PROJPROJ', code='PROJPROJ', category=Account.PROJECT)
+            name='PROJPROJ', code='PROJPROJ', category=Account.PROJECT,
+            goal=200000)
         self.cmpn_acc = Account.objects.create(
             name='CMPNCMPN', code='CMPNCMPN', category=Account.OTHER)
         self.project = Project.objects.create(
@@ -33,7 +34,7 @@ class DonationsTests(TestCase):
         the payment page."""
         response = self.client.get(
             reverse('project form', kwargs={'slug': self.project.slug})
-            + '?amount=2000')
+            + '?payment_amount=20')
         content = response.content.decode('utf-8')
         self.assertEqual(200, response.status_code)
         self.assertTrue('$20.00' in content)
@@ -42,24 +43,34 @@ class DonationsTests(TestCase):
 
         response = self.client.get(
             reverse('campaign form', kwargs={'slug': self.campaign.slug})
-            + '?amount=2000')
+            + '?payment_amount=20.01')
         content = response.content.decode('utf-8')
         self.assertEqual(200, response.status_code)
-        self.assertTrue('$20.00' in content)
+        self.assertTrue('$20.01' in content)
         self.assertTrue(self.cmpn_acc.code)     # Check that this is nonempty
         self.assertTrue(self.cmpn_acc.code in content)
 
     def test_payment_type(self):
         """Check that the payment type values are rendered correctly."""
-
         response = self.client.get(
             reverse('project form', kwargs={'slug': self.project.slug})
-            + '?amount=2000')
+            + '?payment_amount=2000')
         content = response.content.decode('utf-8')
         self.assertTrue('id_payment_type_0' in content)
         self.assertTrue('id_payment_type_1' in content)
         self.assertTrue('CreditCard' in content)
         self.assertTrue('CreditACH' in content)
+
+    def test_check_project_max(self):
+        """Shouldn't be able to donate more than a project's remaining"""
+        response = self.client.get(
+            reverse('project form', kwargs={'slug': self.project.slug})
+            + '?payment_amount=2000')
+        self.assertEqual(200, response.status_code)
+        response = self.client.get(
+            reverse('project form', kwargs={'slug': self.project.slug})
+            + '?payment_amount=2000.01')
+        self.assertEqual(302, response.status_code)
 
     def test_review_page(self):
         """ Test that the donation review page renders with the required
@@ -72,15 +83,13 @@ class DonationsTests(TestCase):
             'billing_state': 'MD',
             'billing_zip':  '20852',
             'country': 'USA',
-            'payment_amount': 2000,
-            'project_code': 'PC-SEC01',
             'payment_type': 'CreditCard',
             'information_consent': 'true',
             'random': 'randVal'}
 
         response = self.client.post(
             reverse('project form', kwargs={'slug': self.project.slug})
-            + '?amount=2000', form_data, HTTP_HOST='example.com')
+            + '?payment_amount=2000', form_data, HTTP_HOST='example.com')
         content = response.content.decode('utf-8')
         self.assertEqual(200, response.status_code)
         self.assertTrue('agency_tracking_id' in content)
@@ -106,41 +115,49 @@ class DonationsTests(TestCase):
             'billing_state': 'MD',
             'billing_zip':  '20852',
             'country': 'USA',
-            'payment_amount': 2000,
-            'project_code': 'PC-SEC01',
             'payment_type': 'CreditCard',
             'information_consent': 'true'}
 
         response = self.client.post(
             reverse('project form', kwargs={'slug': self.project.slug})
-            + '?amount=2000', form_data)
+            + '?payment_amount=2000', form_data)
         self.assertContains(response, 'agency_tracking_id')
         form_data['force_form'] = 'true'
         response = self.client.post(
             reverse('project form', kwargs={'slug': self.project.slug})
-            + '?amount=2000', form_data)
+            + '?payment_amount=2000', form_data)
         self.assertNotContains(response, 'agency_tracking_id')
 
     def test_bad_request_donations(self):
-        """ The donation information page should 400 if donation amount isn't
+        """ The donation information page should redirect if amount isn't
         included."""
         response = self.client.get(
             reverse('project form', kwargs={'slug': self.project.slug}))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 302)
         response = self.client.get(
             reverse('campaign form', kwargs={'slug': self.campaign.slug}))
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 302)
 
     def test_bad_amount(self):
-        """If a non-integer amount is entered, the donation form should 400"""
+        """If a non-numeric amount is entered, the donation form should
+        redirect. Same applies with min/max bounds"""
         response = self.client.get(
             reverse('project form', kwargs={'slug': self.project.slug})
-            + '?amount=aaa')
-        self.assertEqual(response.status_code, 400)
+            + '?payment_amount=aaa')
+        self.assertEqual(response.status_code, 302)
         response = self.client.get(
             reverse('campaign form', kwargs={'slug': self.campaign.slug})
-            + '?amount=aaa')
-        self.assertEqual(response.status_code, 400)
+            + '?payment_amount=aaa')
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.get(
+            reverse('project form', kwargs={'slug': self.project.slug})
+            + '?payment_amount=0.99')
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get(
+            reverse('project form', kwargs={'slug': self.project.slug})
+            + '?payment_amount=10000')
+        self.assertEqual(response.status_code, 302)
 
     def test_completed_success(self):
         response = self.client.get(reverse('donation success'))
@@ -203,7 +220,7 @@ class DonatePagesTests(TestCase):
                                     {'presets': 'custom',
                                      'payment_amount': '123.45'})
         self.assertEqual(response.status_code, 302)
-        self.assertTrue("12345" in response['Location'])
+        self.assertTrue("123.45" in response['Location'])
         self.assertTrue("brick-oven-bakery" in response['Location'])
 
     def test_fund_form_redirect(self):
@@ -212,7 +229,7 @@ class DonatePagesTests(TestCase):
             reverse('donate campaign', kwargs={'slug': 'peace-corps'}),
             {'presets': 'preset-50'})
         self.assertEqual(response.status_code, 302)
-        self.assertTrue("5000" in response['Location'])
+        self.assertTrue("50" in response['Location'])
         self.assertTrue('peace-corps' in response['Location'])
 
     def test_project_fund_prepopulation(self):

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -1,6 +1,8 @@
+from urllib.parse import quote as urlquote
+
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.views.generic import DetailView, ListView
 from django.views.decorators.csrf import csrf_exempt
@@ -29,18 +31,24 @@ def campaign_form(request, slug):
 
 
 def donation_payment(request, account, project=None, campaign=None):
-    """ Collect donor contact information. """
-    amount = request.GET.get('amount')
-    if amount is None:
-        return HttpResponseBadRequest('amount must be provided.')
-    elif not amount.isdigit():
-        return HttpResponseBadRequest('amount must be an integer value')
-    else:
-        amount = int(amount)
+    """Collect donor contact information. Expects a GET param, payment_amount,
+    in dollars."""
+    payment_amount = request.GET.get('payment_amount', '')
+    data = {'presets': 'custom', 'payment_amount': payment_amount}
+    form = DonationAmountForm(data=data, account=account)
+    if not form.is_valid():
+        if project:
+            url = reverse('donate project', kwargs={'slug': project.slug})
+        else:
+            url = reverse('donate campaign', kwargs={'slug': campaign.slug})
+        return HttpResponseRedirect(
+            url + '?payment_amount=' + urlquote(payment_amount)
+            + '#amount-form')
+    # convert to cents
+    payment_amount = int(form.cleaned_data['payment_amount'] * 100)
 
     context = {
-        'amount': amount,
-        'project_code': account.code,
+        'payment_amount': payment_amount,
         'project': project,
         'account_name': account.name,
         'agency_id': settings.PAY_GOV_AGENCY_ID,
@@ -51,12 +59,13 @@ def donation_payment(request, account, project=None, campaign=None):
     if request.method == 'POST':
         form = DonationPaymentForm(request.POST)
     else:
-        form = DonationPaymentForm(initial={
-            'payment_amount': amount, 'project_code': account.code})
+        form = DonationPaymentForm()
     context['form'] = form
 
     if form.is_valid() and request.POST.get('force_form') != 'true':
         data = {k: v for k, v in form.cleaned_data.items()}
+        data['payment_amount'] = payment_amount
+        data['project_code'] = account.code
         paygov = convert_to_paygov(
             data, account, "https://" + request.get_host())
         paygov.save()
@@ -102,24 +111,19 @@ def donate_project(request, slug):
             'volunteerpicture', 'featured_image', 'account', 'overflow'),
         slug=slug)
 
-    if project.account.funded():
-        project_max = None
-    else:
-        project_max = project.account.remaining()
-
     if request.method == 'POST':
-        form = DonationAmountForm(data=request.POST, project_max=project_max)
+        form = DonationAmountForm(data=request.POST, account=project.account)
         if form.is_valid():
-            amount = int(form.cleaned_data['payment_amount'] * 100)
             return HttpResponseRedirect(
                 reverse('project form', kwargs={'slug': slug})
-                + '?amount=' + str(amount))
-    elif request.GET.get('payment_amount'):
+                + '?payment_amount='
+                + str(form.cleaned_data['payment_amount']))
+    elif request.GET.get('payment_amount') is not None:
         data = {'presets': 'custom',
                 'payment_amount': request.GET.get('payment_amount')}
-        form = DonationAmountForm(data=data, project_max=project_max)
+        form = DonationAmountForm(data=data, account=project.account)
     else:
-        form = DonationAmountForm()
+        form = DonationAmountForm(account=project.account)
 
     return render(
         request,
@@ -176,18 +180,18 @@ def fund_detail(request, slug):
     campaign = get_object_or_404(Campaign.objects.select_related('account'),
                                  slug=slug)
     if request.method == "POST":
-        form = DonationAmountForm(data=request.POST)
+        form = DonationAmountForm(data=request.POST, account=campaign.account)
         if form.is_valid():
-            amount = int(form.cleaned_data['payment_amount'] * 100)
             return HttpResponseRedirect(
                 reverse('campaign form', kwargs={'slug': slug})
-                + '?amount=' + str(amount))
-    elif request.GET.get('payment_amount'):
+                + '?payment_amount='
+                + str(form.cleaned_data['payment_amount']))
+    elif request.GET.get('payment_amount') is not None:
         data = {'presets': 'custom',
                 'payment_amount': request.GET.get('payment_amount')}
-        form = DonationAmountForm(data=data)
+        form = DonationAmountForm(data=data, account=campaign.account)
     else:
-        form = DonationAmountForm()
+        form = DonationAmountForm(account=campaign.account)
 
     return render(
         request,

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
+from django.utils.crypto import get_random_string
 from django.views.generic import DetailView, ListView
 from django.views.decorators.csrf import csrf_exempt
 
@@ -43,7 +44,7 @@ def donation_payment(request, account, project=None, campaign=None):
             url = reverse('donate campaign', kwargs={'slug': campaign.slug})
         return HttpResponseRedirect(
             url + '?payment_amount=' + urlquote(payment_amount)
-            + '#amount-form')
+            + '&nonce=' + get_random_string(12) + '#amount-form')
     # convert to cents
     payment_amount = int(form.cleaned_data['payment_amount'] * 100)
 


### PR DESCRIPTION
This is the next step towards donation amount buttons (and the associated CSRF fix). This adds an amount check to the donor info form, running it through the same form object which is on the project/campaign pages. If the amount is bad, the user is redirected to the project/campaign amount form, where the error message is displayed.
- As the custom amount is entered in dollars, the amount read on the donor info form must be in dollars, not cents
- As the accounting code is implicit by the url and the donation amount is already checked, these hidden fields can be removed from the donor info form
- Standardize on `payment_amount` over `amount`
- Amount is verified both on initial page load and before processing the donor info input, meaning that if a project change causes the amount to be invalid, the user will get redirected
- Added a nonce to break the cache if the user is redirected -- to account for a new amount remaining. We could tighten this up is it proves too taxing, but I doubt there will be many payment amount validation errors
- Populate the amount form (on the project/campaign page) with the requested amount
