### PR TITLE
Removed "All Rights Reserved" from Footer

### DIFF
--- a/peacecorps/peacecorps/templates/donations/base.jinja
+++ b/peacecorps/peacecorps/templates/donations/base.jinja
@@ -158,10 +158,7 @@
         <li class="sub_nav__link">
           <a class="t-body--sm"
              href="http://www.peacecorps.gov/about/policies/foia/">
-            Freedom of Information Guide</a>
-        </li>
-        <li class="sub_nav__link t-body--sm">
-          All Rights Reserved.
+            Freedom of Information</a>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
Proposing that we remove "All Rights Reserved" from the footer. This is for a number of reasons:
1. It's ambiguous. What rights are we referring to? This is normally (incorrectly) used in conjunction with copyright, so we can just assume that.
2. It's meaningless. Unlike trademarks, where the work must be aggressively protected in order to retain the trademark, copyright does not need to be expressly stated for a copyright to take effect.
3. The Peace Corps doesn't hold copyright to the content of the website, so it's factually incorrect to state that rights are reserved. As a work of the United States Government, content on peacecorps.gov is in the public domain. Particular rights may be embedded in statutes for things like the seal (22 U.S. Code § 2518 deals with the Peace Corps seal in particular), but that's a bit different than stating "All Rights Reserved" across the entire site.
