### PR TITLE
Data errors

### DIFF
--- a/peacecorps/peacecorps/migrations/0059_auto_20150120_1550.py
+++ b/peacecorps/peacecorps/migrations/0059_auto_20150120_1550.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import re
+
+from django.db import migrations
+
+from peacecorps.management.commands.sync_accounting import clean_description
+
+
+def clean(apps, schema_editor):
+    """Cleans the description field for imported projects/funds"""
+    for campaign in apps.get_model("peacecorps", "Campaign").objects.all():
+        campaign.description = clean_description(campaign.description)
+        campaign.description = re.sub(r"(?<!\\)\n", r"\\n",
+                                      campaign.description)
+        campaign.save()
+
+    for project in apps.get_model("peacecorps", "Project").objects.all():
+        project.description = clean_description(project.description)
+        project.description = re.sub(r"(?<!\\)\n", r"\\n", project.description)
+        project.save()
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0058_remove_project_volunteerhomecity'),
+    ]
+
+    operations = [
+        migrations.RunPython(clean, noop)
+    ]

--- a/peacecorps/peacecorps/migrations/0060_auto_20150120_1630.py
+++ b/peacecorps/peacecorps/migrations/0060_auto_20150120_1630.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0059_auto_20150120_1550'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='campaign',
+            name='slug',
+            field=models.SlugField(help_text='Auto-generated. Used for the campaign page url.', max_length=120, unique=True),
+        ),
+        migrations.AlterField(
+            model_name='country',
+            name='name',
+            field=models.CharField(max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='name',
+            field=models.CharField(max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='media',
+            name='title',
+            field=models.CharField(max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='slug',
+            field=models.SlugField(help_text='for the project url.', max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='title',
+            field=models.CharField(max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='volunteername',
+            field=models.CharField(max_length=120),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -18,6 +18,9 @@ from peacecorps.fields import GPGField, BraveSirTrevorField
 from peacecorps.util import svg
 
 
+NAME_LENGTH = 120   # Consistent length for project/account/fund names
+
+
 def imagesave(description):
     """Saves images from Sir Trevor fields to the media model."""
     if not description:
@@ -56,7 +59,7 @@ class Account(models.Model):
         (PROJECT, 'Project'),
     )
 
-    name = models.CharField(max_length=120, unique=True)
+    name = models.CharField(max_length=NAME_LENGTH, unique=True)
     code = models.CharField(max_length=25, primary_key=True)
     current = models.IntegerField(
         default=0,
@@ -158,7 +161,7 @@ class Campaign(models.Model):
         (TAG, 'Tag')
     )
 
-    name = models.CharField(max_length=120)
+    name = models.CharField(max_length=NAME_LENGTH)
     account = models.ForeignKey('Account', unique=True)
     campaigntype = models.CharField(
         max_length=10, choices=CAMPAIGNTYPE_CHOICES)
@@ -176,7 +179,7 @@ class Campaign(models.Model):
         blank=True, null=True)
     slug = models.SlugField(
         help_text="Auto-generated. Used for the campaign page url.",
-        max_length=100, unique=True)
+        max_length=NAME_LENGTH, unique=True)
     description = BraveSirTrevorField(help_text="the full description.")
     featuredprojects = models.ManyToManyField('Project', blank=True, null=True)
     country = models.ForeignKey(
@@ -206,7 +209,7 @@ class SectorMapping(models.Model):
 
 class Country(models.Model):
     code = models.CharField(max_length=5)
-    name = models.CharField(max_length=50)
+    name = models.CharField(max_length=NAME_LENGTH)
 
     def __str__(self):
         return '%s (%s)' % (self.name, self.code)
@@ -248,7 +251,7 @@ class Media(models.Model):
         (OTHER, "Other"),
     )
 
-    title = models.CharField(max_length=100)
+    title = models.CharField(max_length=NAME_LENGTH)
     file = models.FileField()
     mediatype = models.CharField(
         max_length=3, choices=MEDIATYPE_CHOICES, default=IMAGE)
@@ -298,11 +301,12 @@ class PublishedManager(models.Manager):
 
 
 class Project(models.Model):
-    title = models.CharField(max_length=100)
+    title = models.CharField(max_length=NAME_LENGTH)
     tagline = models.CharField(
         max_length=240, help_text="a short description for subheadings.",
         blank=True, null=True)
-    slug = models.SlugField(max_length=100, help_text="for the project url.")
+    slug = models.SlugField(max_length=NAME_LENGTH,
+                            help_text="for the project url.")
     description = BraveSirTrevorField(help_text="the full description.")
     country = models.ForeignKey('Country', related_name="projects")
     campaigns = models.ManyToManyField(
@@ -319,7 +323,7 @@ class Project(models.Model):
         'Account', blank=True, null=True, related_name='overflow',
         help_text="""Select another fund to which users will be directed to
                     donate if the project is already funded.""")
-    volunteername = models.CharField(max_length=100)
+    volunteername = models.CharField(max_length=NAME_LENGTH)
     volunteerpicture = models.ForeignKey(
         'Media', related_name="volunteer", blank=True, null=True)
     volunteerhomestate = USPostalCodeField(blank=True, null=True)
@@ -382,7 +386,7 @@ class Project(models.Model):
 class Issue(models.Model):
     """A categorization scheme. This could eventually house relationships with
     individual projects, but for now, just point to sector funds"""
-    name = models.CharField(max_length=100)
+    name = models.CharField(max_length=NAME_LENGTH)
     icon = models.FileField(    # No need for any of the 'Media' fields
         help_text="Icon commonly used to represent this issue",
         upload_to='icons', validators=[svg.full_validation])

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -340,3 +340,23 @@ class SyncAccountingTests(TestCase):
 
         text = "\n\r\nSome<BR><br /></BR>Text"
         self.assertEqual(sync.clean_description(text), "\n\r\nSome\n\nText")
+
+    def test_trim_row(self):
+        """Verify that rows are trimmed to the required length and logs are
+        emitted"""
+        row = {'PROJ_NO': 'A'*500, 'LOCATION': 'B'*500, 'CHANGE_DATE': 'C'*500,
+               'PROJ_NAME1': 'D'*500, 'PCV_NAME': 'E'*500, 'SUMMARY': 'F'*500,
+               'STATE': 'G'*500, 'OVERS_PART': 'H'*500, 'OVERS_PCT': 'I'*500,
+               'PROJ_REQ': 'J'*500, 'UNIDENT_BAL': 'K'*500,
+               'ATTRIBUTE4': 'L'*500, 'SECTOR': 'M'*500, 'SUB_SECTOR': 'N'*500,
+               'LAST_UPDATED_FROM_PAYGOV': 'O'*500}
+        should_trim = ('PROJ_NO', 'LOCATION', 'PROJ_NAME1', 'PCV_NAME',
+                       'STATE', 'SECTOR')
+        no_trim = [key for key in row if key not in should_trim]
+        logger = Mock()
+        row = sync.trim_row(row, logger)
+        for key in should_trim:
+            self.assertTrue(len(row[key]) < 500)
+        for key in no_trim:
+            self.assertEqual(len(row[key]), 500)
+        self.assertEqual(logger.warning.call_count, len(should_trim))

--- a/peacecorps/peacecorps/tests/test_sync_accounting.py
+++ b/peacecorps/peacecorps/tests/test_sync_accounting.py
@@ -328,3 +328,15 @@ class SyncAccountingTests(TestCase):
                'LOCATION': 'D/OSP/GGM', 'PROJ_NAME1': 'General Fund',
                'PCV_NAME': 'General Fund', 'OVERS_PART': ''}
         self.assertEqual(Account.OTHER, sync.account_type(row))
+
+    def test_clean_description(self):
+        """Clean description replaces bad bytes and BRs"""
+        text = '!@#$%^&*()_+1234567890-='
+        self.assertEqual(sync.clean_description(text),
+                         '!@#$%^&*()_+1234567890-=')
+
+        text = "Darwin\u00c2\u00bfs Bulldog"
+        self.assertEqual(sync.clean_description(text), "Darwin's Bulldog")
+
+        text = "\n\r\nSome<BR><br /></BR>Text"
+        self.assertEqual(sync.clean_description(text), "\n\r\nSome\n\nText")


### PR DESCRIPTION
This PR handles a few data errors which arise during import
- There's a repeated bad character encoding for an apostrophe; these errors are displayed incorrectly on their existing site
- Convert BRs to new lines
- Field content length checks were not enforced
- Add a consistent length (120) for most "name"-like fields. We can easily change this in the future if desired
