### PR TITLE
Display projects by country rather than country fund

### DIFF
--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -114,8 +114,8 @@
         country.country.name,
         country) }}
     </li>
-    {# TODO figure out projects rather the featured projects #}
-    {% for project in country.project_set.all() %}
+    {# Must use "get" as they key is a variable #}
+    {% for project in projects_by_country.get(country.country.code, []) %}
       <li class="section section--neutral_medium
           u-clearfix
           bordered

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from urllib.parse import quote as urlquote
 
 from django.conf import settings
@@ -147,6 +148,9 @@ def donate_projects_funds(request):
     issues = Issue.objects.all().order_by('name')
     projects = Project.published_objects.select_related(
         'country', 'account').order_by('volunteername')
+    projects_by_country = defaultdict(list)
+    for project in projects:
+        projects_by_country[project.country.code].append(project)
 
     return render(
         request,
@@ -156,6 +160,7 @@ def donate_projects_funds(request):
             'countries': countries,
             'issues': issues,
             'projects': projects,
+            'projects_by_country': projects_by_country,
         })
 
 


### PR DESCRIPTION
Fixes logic which sorts projects by country. Prior, this was checking the country fund for associated projects. Instead, this looks for projects that have the specified country (i.e. no direct relation to the fund).

Note that this exacerbates the problem where projects do not start hidden when sorting by country (as all the projects are now visible)
