### PR TITLE
Sorter: Country tab, Counts

### DIFF
--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -34,12 +34,14 @@
   <ul class="js-filterable u-unmarked_list u-clearfix" id="issue"
       data-filter-type="issue">
   {% for issue in issues %}
+    {% set issue_projects = issue.projects() %}
     <li id="page-issue-{{ issue.id }}">
       <a href="#" aria-controls="collapsible-page-issue-{{ issue.id }}"
           class="js-pageNav section section--neutral_medium bordered bordered--row
           bordered--white u-clearfix section__content--xsm t-link--no_underline
           t-link--gray">
-        {{ render_link_header(issue.icon_color_url('grey'), issue.name, issue.name) }}
+        {{ render_link_header(issue.icon_color_url('grey'), issue.name,
+                              issue.name, issue_projects|length) }}
       </a>
     </li>
     {% for campaign in issue.campaigns.all() %}
@@ -60,7 +62,7 @@
     </li>
     {% endfor %}
       {# TODO figure out projects rather the featured projects #}
-    {% for project in issue.projects() %}
+    {% for project in issue_projects %}
       <li data-page-id="collapsible-page-issue-{{ issue.id }}"
           class="js-page
           section section--neutral_medium
@@ -91,14 +93,19 @@
   <ul class="js-filterable u-unmarked_list u-clearfix" id="country"
       data-filter-type="country">
   {% for country in countries %}
+    {# Must use "get" as they key is a variable #}
+    {% set country_projects = projects_by_country.get(country.country.code,
+                                                      []) %}
     <li id="page-country-{{ country.id }}">
       <a href="#" aria-controls="collapsible-page-country-{{ country.id }}"
           class="js-pageNav section section--neutral_medium bordered bordered--row
           bordered--white u-clearfix section__content--xsm t-link--no_underline
           t-link--gray">
       {{ render_link_header(
-        static("peacecorps/img/countries/" + country.country.code.lower() + ".svg"),
-          country.country.name, country.country.name) }}
+          static("peacecorps/img/countries/" + country.country.code.lower()
+                 + ".svg"),
+          country.country.name, country.country.name,
+          country_projects|length) }}
       </a>
     </li>
     <li data-page-id="collapsible-page-country-{{ country.id }}"
@@ -114,9 +121,10 @@
         country.country.name,
         country) }}
     </li>
-    {# Must use "get" as they key is a variable #}
-    {% for project in projects_by_country.get(country.country.code, []) %}
-      <li class="section section--neutral_medium
+    {% for project in country_projects %}
+      <li data-page-id="collapsible-page-country-{{ country.id }}"
+          class="js-page
+          section section--neutral_medium
           u-clearfix
           bordered
           bordered--row
@@ -192,7 +200,7 @@
   </a>
 {%- endmacro %}
 
-{% macro render_link_header(url, alt, name) -%}
+{% macro render_link_header(url, alt, name, count) -%}
   <aside class="column column--third
       enclose--sm
       sm-hide">
@@ -208,7 +216,12 @@
   </aside>
   <header class="column column--half" style="height: 4em;">
       <h4 class="t-heading--4 t--gray--2 u-v_center--block t-nom">
-        {{ name }}</h4>
+        {% if count is defined %}
+        {{ name }} ({{count}})
+        {% else %}
+        {{ name }}
+        {% endif %}
+      </h4>
   </header>
 {%- endmacro %}
 

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -184,6 +184,23 @@ class DonationsTests(TestCase):
         self.assertEqual(302, response.status_code)
         self.assertTrue(self.campaign.slug in response['LOCATION'])
 
+    def test_the_gambia_order(self):
+        """We should be sorting by country name, not campaign name"""
+        acc_a = Account.objects.create(name='AAA', code='AAA')
+        acc_b = Account.objects.create(name='BBB', code='BBB')
+        Campaign.objects.create(
+            campaigntype=Campaign.COUNTRY, slug='aaa', account=acc_a,
+            country=Country.objects.get(name='Mexico'), name='AAA')
+        Campaign.objects.create(
+            campaigntype=Campaign.COUNTRY, slug='bbb', account=acc_b,
+            country=Country.objects.get(name='Gambia'), name='BBB')
+        response = self.client.get(reverse('donate projects funds'))
+        response = response.content.decode('utf-8')
+        self.assertTrue(response.index('Mexico') > response.index('Gambia'))
+        self.assertTrue(response.index('AAA') > response.index('BBB'))
+        acc_b.delete()
+        acc_a.delete()
+
 
 class DonatePagesTests(TestCase):
 

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -143,8 +143,8 @@ def donate_projects_funds(request):
     """
     The page that displays a sorter for all projects, issues, volunteers.
     """
-    countries = Campaign.objects.filter(
-        campaigntype=Campaign.COUNTRY).order_by('name')
+    countries = Campaign.objects.select_related('country').filter(
+        campaigntype=Campaign.COUNTRY).order_by('country__name')
     issues = Issue.objects.all().order_by('name')
     projects = Project.published_objects.select_related(
         'country', 'account').order_by('volunteername')


### PR DESCRIPTION
This PR adds/fixes three things:
- The country tab only displays projects when the associated country is clicked (bug fix)
- The country tab sorts elements by country name, rather than fund name (bug fix)
- Both the issues tab and the country tab now include counts of projects in that category

![screen shot 2015-01-26 at 11 51 27 am](https://cloud.githubusercontent.com/assets/326918/5904939/ff751d36-a551-11e4-8926-e2b89207d4f9.png)
![screen shot 2015-01-26 at 11 51 36 am](https://cloud.githubusercontent.com/assets/326918/5904940/ff79bd6e-a551-11e4-8ec6-e34f4f07845d.png)
![screen shot 2015-01-26 at 11 51 45 am](https://cloud.githubusercontent.com/assets/326918/5904941/ff7b7ef6-a551-11e4-9d89-ff00402d5d93.png)
