### PR TITLE
Account for repeated projects

### DIFF
--- a/peacecorps/peacecorps/templates/donations/checkout_base.jinja
+++ b/peacecorps/peacecorps/templates/donations/checkout_base.jinja
@@ -20,7 +20,7 @@
           {{ humanize_cents(payment_amount) }}</h1>
         <h4 class="t-heading--stylized">to</h4><br>
         <h3 class="t-heading--stylized">
-          <strong>{{ project.title or account_name }}</strong></h3>
+          <strong>{{ project.title or campaign.name }}</strong></h3>
       </div>
   </section>
 

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -70,8 +70,8 @@
           bordered
           bordered--row
           bordered--white">
-        {{ render_project_header(project, 'issue') }}
-        {{ render_project(project, 'issue') }}
+        {{ render_project_header(project, 'issue-' ~ issue.id) }}
+        {{ render_project(project, 'issue-' ~ issue.id) }}
       </li>
     {% endfor %}
   {% endfor %}

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -63,7 +63,7 @@ def donation_payment(request, account, project=None, campaign=None):
         'title': 'Giving Checkout',
         'payment_amount': payment_amount,
         'project': project,
-        'account_name': account.name,
+        'campaign': campaign,
         'agency_id': settings.PAY_GOV_AGENCY_ID,
         'app_name': settings.PAY_GOV_APP_NAME,
         'oci_servlet_url': settings.PAY_GOV_OCI_URL,


### PR DESCRIPTION
- Allow a project to be categorized under multiple campaigns/funds (and hence multiple issues) by giving it unique controls each time it appears
- Fix an unrelated test that broke when updating the initialization of the tests by passing in campaign names (rather than account names)
