### PR TITLE
Added login warning to admin page

### DIFF
--- a/peacecorps/peacecorps/templates/admin/login.html
+++ b/peacecorps/peacecorps/templates/admin/login.html
@@ -1,0 +1,60 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_static %}
+
+{% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/login.css" %}" />{% endblock %}
+
+{% block bodyclass %}{{ block.super }} login{% endblock %}
+
+{% block usertools %}{% endblock %}
+
+{% block nav-global %}{% endblock %}
+
+{% block content_title %}{% endblock %}
+
+{% block breadcrumbs %}{% endblock %}
+
+{% block content %}
+{% if form.errors and not form.non_field_errors %}
+<p class="errornote">
+{% if form.errors.items|length == 1 %}{% trans "Please correct the error below." %}{% else %}{% trans "Please correct the errors below." %}{% endif %}
+</p>
+{% endif %}
+
+{% if form.non_field_errors %}
+{% for error in form.non_field_errors %}
+<p class="errornote">
+    {{ error }}
+</p>
+{% endfor %}
+{% endif %}
+
+<div id="content-main">
+<div class="warning">
+You are accessing a system operated by 18F, a division of the General Services Administration of the United States Government, on behalf of the United States Peace Corps. Unauthorized use of this system is prohibited and subject to criminal and civil penalties. By accessing this system, you are consenting to monitoring and have no expectation of privacy.
+</div>
+<form action="{{ app_path }}" method="post" id="login-form">{% csrf_token %}
+  <div class="form-row">
+    {{ form.username.errors }}
+    {{ form.username.label_tag }} {{ form.username }}
+  </div>
+  <div class="form-row">
+    {{ form.password.errors }}
+    {{ form.password.label_tag }} {{ form.password }}
+    <input type="hidden" name="next" value="{{ next }}" />
+  </div>
+  {% url 'admin_password_reset' as password_reset_url %}
+  {% if password_reset_url %}
+  <div class="password-reset-link">
+    <a href="{{ password_reset_url }}">{% trans 'Forgotten your password or username?' %}</a>
+  </div>
+  {% endif %}
+  <div class="submit-row">
+    <label>&nbsp;</label><input type="submit" value="{% trans 'Log in' %}" />
+  </div>
+</form>
+
+<script type="text/javascript">
+document.getElementById('id_username').focus()
+</script>
+</div>
+{% endblock %}


### PR DESCRIPTION
Okay, so this solves https://github.com/18F/peace-corps-product-management/issues/209 but I'm not sure if there is a more elegant way to handle it. Basically, I'm overwriting the entire `admin/login.html` template. Extending the template didn't seem to provide much utility, as then I would have had to extend the base template as well, at least if I understand non-app admin template changes properly. Thoughts?
