### PR TITLE
Replaced language on memorial page

### DIFF
--- a/peacecorps/peacecorps/templates/donations/memorial_funds.jinja
+++ b/peacecorps/peacecorps/templates/donations/memorial_funds.jinja
@@ -7,7 +7,7 @@
 
 <section class="blurb blurb--lg">
   <div class="t-blurb--md t--black">
-    Since the Peace Corps began in 1961, more than 200,000 Peace Corps Volunteers have served in 139 countries.  Of these dedicated men and women, 297 have sacrificed not only their energies and time, but also their lives while pursuing the Peace Corps mission. They are remembered here on this site, so that all may honor and celebrate their lives and service.
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   </div>
 </section>
 <section class="section inset--lg">


### PR DESCRIPTION
Realized the language I put in wasn't actually from Peace Corps, but instead from an external organization. Replacing this until we have official language to use.
