### PR TITLE
Add abstract to funds

### DIFF
--- a/peacecorps/contenteditor/admin.py
+++ b/peacecorps/contenteditor/admin.py
@@ -36,7 +36,7 @@ class CampaignAdmin(admin.ModelAdmin):
             'fields': ['account', 'name', ('campaigntype', 'country'), 'icon']
             }),
         ('Text', {
-            'fields': ['slug', 'description']
+            'fields': ['slug', 'description', 'abstract']
         }),
     )
 

--- a/peacecorps/peacecorps/migrations/0061_campaign_abstract.py
+++ b/peacecorps/peacecorps/migrations/0061_campaign_abstract.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0060_auto_20150120_1630'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='campaign',
+            name='abstract',
+            field=models.TextField(null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -194,7 +194,7 @@
         {{ campaign.name }}
       </a>
     </h3>
-    {{ campaign.description.html|safe }}
+    {{ campaign.abstract_html()|safe }}
     <a class="button button--sm button--primary"
        href="{{ url("donate campaign", slug=campaign.slug) }}">
       Give to this fund</a>

--- a/peacecorps/peacecorps/templates/donations/memorial_funds.jinja
+++ b/peacecorps/peacecorps/templates/donations/memorial_funds.jinja
@@ -28,7 +28,7 @@
               <a href="{{url("donate campaign", slug=fund.slug)}}">
                 <h3 class="t-heading--3 t--primary">{{ fund.memorial_name }}</h3>
               </a>
-              <p>{{ fund.description.html|safe }}</p>
+              <p>{{ fund.abstract_html()|safe }}</p>
             </article>
         </section>
       {% endfor %}


### PR DESCRIPTION
Moves `abstract_html()` into a mixin which both `Campaign` and `Project` share. Adds an `abstract` field to funds so this can be overwritten.

No new tests as the functionality is already tested on projects, but I did confirm that it works:

![screen shot 2015-01-30 at 1 20 32 pm](https://cloud.githubusercontent.com/assets/326918/5981794/d8b0610e-a882-11e4-90d3-26f886f63d0a.png)
![screen shot 2015-01-30 at 1 19 55 pm](https://cloud.githubusercontent.com/assets/326918/5981797/de309b58-a882-11e4-8789-d01baecfe79c.png)
