### PR TITLE
Better highlights for eastern caribbean

### DIFF
--- a/peacecorps/peacecorps/static/peacecorps/img/countries/esc.svg
+++ b/peacecorps/peacecorps/static/peacecorps/img/countries/esc.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" class="world_map" height="127" id="svg2985" version="1.1" viewBox="700 560 125 125" width="127">
+<svg xmlns="http://www.w3.org/2000/svg" class="world_map" height="127" id="svg2985" version="1.1" viewBox="755 590 90 90" width="127">
   <title>World Map</title>
   <defs id="defs2987"/>
   <style id="style_css_sheet" type="text/css">
@@ -13,31 +13,6 @@
 }
 .world_map .landxx {
   fill: #F2EFE8;
-  stroke: #ffffff;
-  fill-rule: evenodd;
-}
-.world_map.zoom6 .landxx {
-  stroke-width: 0.1px;
-}
-.world_map.zoom5 .landxx {
-  stroke-width: 1px;
-}
-.world_map.zoom4 .landxx {
-  stroke-width: 2px;
-}
-.world_map.zoom3 .landxx {
-  stroke-width: 3px;
-}
-.world_map.zoom2 .landxx {
-  stroke-width: 4px;
-}
-.world_map.zoom1 .landxx {
-  stroke-width: 5px;
-}
-.world_map .coastxx {
-  fill: #F2EFE8;
-  stroke: #ffffff;
-  stroke-width: 2px;
   fill-rule: evenodd;
 }
 .world_map .oceanxx {
@@ -176,9 +151,9 @@
         <path d="M 808.39528,622.22153 C 807.78728,621.59453 807.90728,621.28353 808.75528,621.28553 808.87628,621.69553 808.75628,622.00753 808.39528,622.22153" id="path2586"/>
       </g>
       </g>
-    <g id="mq">
+    <g id="mq" class="world_map-is_selected">
       <title>Martinique</title>
-      <path class="landxx coastxx eu mtq fra" d="M 810.33629,634.96555 C 809.75329,634.07255 809.03629,634.83255 808.75229,633.98655 808.47729,633.16755 808.10629,632.28055 808.09529,631.40355 808.08129,630.25455 809.27629,631.25955 809.58929,631.65355 810.19929,632.42055 811.05129,634.01455 810.33629,634.96555" id="mq-"/>
+      <path class="landxx coastxx eu mtq fra world_map-is_selected" d="M 810.33629,634.96555 C 809.75329,634.07255 809.03629,634.83255 808.75229,633.98655 808.47729,633.16755 808.10629,632.28055 808.09529,631.40355 808.08129,630.25455 809.27629,631.25955 809.58929,631.65355 810.19929,632.42055 811.05129,634.01455 810.33629,634.96555" id="mq-"/>
       </g>
     </g>
   <g class="landxx coastxx dom" id="do" transform="translate(-29.9017,-45.0745)">
@@ -251,9 +226,9 @@
     <title>Sint Maarten (Dutch Part)</title>
     <path class="landxx sxm" d="M 796.82028,603.35034 C 796.68487,603.73456 796.60714,603.48066 796.54252,603.58595 796.49082,603.67015 796.34867,603.51025 796.25534,603.45725 796.16204,603.40425 796.27664,603.34403 796.20784,603.28553" id="sx-"/>
     </g>
-  <g id="dm">
+  <g id="dm" class="world_map-is_selected">
     <title>Dominica</title>
-    <path class="landxx coastxx dma" d="M 807.09629,628.05355 C 806.98529,626.91155 806.01229,625.52355 806.59629,624.38155 808.11329,624.76955 808.90829,627.49755 807.09629,628.05355" id="dm-"/>
+    <path class="landxx coastxx dma world_map-is_selected" d="M 807.09629,628.05355 C 806.98529,626.91155 806.01229,625.52355 806.59629,624.38155 808.11329,624.76955 808.90829,627.49755 807.09629,628.05355" id="dm-"/>
     </g>
   <g id="ag">
     <title>Antigua and Barbuda</title>
@@ -262,9 +237,9 @@
       <path d="M 806.09628,607.82153 C 805.51828,607.71053 805.17328,607.25853 805.22628,606.67053 806.06528,606.37453 806.32928,607.16653 806.09628,607.82153" id="path6118"/>
     </g>
     </g>
-  <g id="bb">
+  <g id="bb" class="world_map-is_selected">
     <title>Barbados</title>
-    <path class="landxx coastxx brb" d="M 819.55629,646.62955 C 818.59729,646.21955 818.76629,645.31855 818.76629,644.46955 819.56829,644.76755 821.03629,646.10555 819.55629,646.62955" id="bb-"/>
+    <path class="landxx coastxx brb world_map-is_selected" d="M 819.55629,646.62955 C 818.59729,646.21955 818.76629,645.31855 818.76629,644.46955 819.56829,644.76755 821.03629,646.10555 819.55629,646.62955" id="bb-"/>
     </g>
   <g id="tc">
     <title>Turks and Caicos Islands</title>
@@ -274,17 +249,17 @@
       <path d="M 737.11628,572.18153 C 736.86128,571.95653 736.62128,571.71653 736.39628,571.46153 737.05728,571.40853 737.00128,571.66553 737.11628,572.18153" id="path5534"/>
     </g>
     </g>
-  <g id="vc">
+  <g id="vc" class="world_map-is_selected">
     <title>Saint Vincent and the Grenadines</title>
-    <path class="landxx coastxx vct" d="M 807.02629,645.98155 C 806.00529,645.36355 806.71229,644.39655 807.24629,643.75055 807.77429,644.48555 807.52829,645.32355 807.02629,645.98155" id="vc-"/>
+    <path class="landxx coastxx vct world_map-is_selected" d="M 807.02629,645.98155 C 806.00529,645.36355 806.71229,644.39655 807.24629,643.75055 807.77429,644.48555 807.52829,645.32355 807.02629,645.98155" id="vc-"/>
     </g>
-  <g id="lc">
+  <g id="lc" class="world_map-is_selected">
     <title>Saint Lucia</title>
-    <path class="landxx coastxx lca" d="M 809.18529,640.94155 C 807.79529,640.38655 808.51929,638.96155 809.18529,638.13355 810.21029,638.67655 809.85929,640.27155 809.18529,640.94155" id="lc-"/>
+    <path class="landxx coastxx lca world_map-is_selected" d="M 809.18529,640.94155 C 807.79529,640.38655 808.51929,638.96155 809.18529,638.13355 810.21029,638.67655 809.85929,640.27155 809.18529,640.94155" id="lc-"/>
     </g>
-  <g id="gd">
+  <g id="gd" class="world_map-is_selected">
     <title>Grenada</title>
-    <path class="landxx coastxx grd" d="M 802.48629,655.70155 C 801.71829,654.96955 802.36229,654.03355 803.13629,653.68455 803.42629,654.44355 803.19229,655.27155 802.48629,655.70155" id="gd-"/>
+    <path class="landxx coastxx grd world_map-is_selected" d="M 802.48629,655.70155 C 801.71829,654.96955 802.36229,654.03355 803.13629,653.68455 803.42629,654.44355 803.19229,655.27155 802.48629,655.70155" id="gd-"/>
     </g>
   <g id="kn">
     <title>Saint Kitts and Nevis</title>


### PR DESCRIPTION
Looks like

![screen shot 2015-02-03 at 12 15 56 pm](https://cloud.githubusercontent.com/assets/326918/6026220/9c816e20-ab9e-11e4-89fe-ec3ac86fd3ed.png)

Not great, but a step up. Zoomed out pretty far to show surrounding areas. Unfortunately, the detail of the underlying map is not granular enough to get much more than tear drop shapes, so zooming in is a bad idea.
