### PR TITLE
Simplified publication styleguide

### DIFF
--- a/peacecorps/peacecorps/static/peacecorps/Gruntfile.js
+++ b/peacecorps/peacecorps/static/peacecorps/Gruntfile.js
@@ -132,12 +132,6 @@ module.exports = function(grunt) {
         fontPath: '../../../../fonts'
       }
     },
-    'gh-pages': {
-      options: {
-        base: './resources'
-      },
-      src: ['**']
-    },
     exec: {
       styleguide: {
         cmd: 'kss-node css/src/ resources/styleguide/ --template css/src/donation-styleguide/'
@@ -167,7 +161,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
 
   grunt.loadNpmTasks('grunt-browserify');
-  grunt.loadNpmTasks('grunt-gh-pages');
   grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-env');
   grunt.loadNpmTasks('grunt-exec');
@@ -188,11 +181,11 @@ module.exports = function(grunt) {
       'uglify',
       'styleguide'
       ]);
-  grunt.registerTask('styleguide', ['env:test',
+  grunt.registerTask('styleguide', [
+      'env:test',
       'exec:styleguide',
       'copy:stylesheetCss'
       ]);
   grunt.registerTask('test', ['env:test', 'jshint', 'testling']);
   grunt.registerTask('build-watch', ['browserify:withWatch', 'watch']);
-  grunt.registerTask('publish-resources', ['gh-pages']);
 };

--- a/peacecorps/peacecorps/static/peacecorps/README.md
+++ b/peacecorps/peacecorps/static/peacecorps/README.md
@@ -3,6 +3,11 @@ peacecorps-site-frontend
 
 The frontend portion of the peacecorp site, with CSS and JS dependencies.
 
+## Styleguide
+
+[styleguide] (https://rawgit.com/18F/peacecorps-site/master/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-base.html)
+
+
 ## Development
 We use nodejs, node-sass, Bourbon, and Neat for our front-end stack.
 

--- a/peacecorps/peacecorps/static/peacecorps/css/src/donation-styleguide/index.html
+++ b/peacecorps/peacecorps/static/peacecorps/css/src/donation-styleguide/index.html
@@ -10,10 +10,18 @@
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0,
+      maximum-scale=1.0, user-scalable=0">
   <meta name="viewport" content="width=device-width">
 
   <link rel="stylesheet" href="public/kss.css">
   <link rel="stylesheet" href="donation.css">
+  <link rel="stylesheet" type="text/css"
+    href="//cloud.typography.com/6638272/662206/css/fonts.css" />
+  <noscript>
+    <link href='http://fonts.googleapis.com/css?family=Lato:300,400'
+          rel='stylesheet' type='text/css'>
+  </noscript>
   {{{styles}}}
 </head>
 <body id="kss-node">
@@ -160,5 +168,20 @@
 {{/if}}
 
 <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+<script type="text/javascript">
+WebFontConfig = {
+  google: { families: [ 'Lato:300,400:latin' ] }
+};
+(function() {
+  var wf = document.createElement('script');
+  wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+    '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+  wf.type = 'text/javascript';
+  wf.async = 'true';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(wf, s);
+})();
+</script>
+
 </body>
 </html>

--- a/peacecorps/peacecorps/static/peacecorps/css/src/styleguide.md
+++ b/peacecorps/peacecorps/static/peacecorps/css/src/styleguide.md
@@ -15,5 +15,6 @@ This guide can be used as a reference to use the CSS system as well as a testing
 environment for visuals of the site.
 
 ## Contents
+##### [base](section-base.html)
 ##### [components](section-components.html)
 ##### [modules](section-modules.html)

--- a/peacecorps/peacecorps/static/peacecorps/package.json
+++ b/peacecorps/peacecorps/static/peacecorps/package.json
@@ -35,7 +35,6 @@
     "grunt-exec": "^0.4.6",
     "grunt-exorcise": "^0.2.0",
     "grunt-font-awesome-vars": "^1.0.1",
-    "grunt-gh-pages": "^0.9.1",
     "grunt-sass": "^0.17.0",
     "grunt-testling": "^1.0.0",
     "grunt-timer": "^0.5.8",

--- a/peacecorps/peacecorps/static/peacecorps/resources/README.md
+++ b/peacecorps/peacecorps/static/peacecorps/resources/README.md
@@ -1,0 +1,5 @@
+# Developer resources
+
+All developer resources for the Peace Corps site.
+
+- [styleguide] (https://rawgit.com/18F/peacecorps-site/master/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-base.html)

--- a/peacecorps/peacecorps/static/peacecorps/resources/index.md
+++ b/peacecorps/peacecorps/static/peacecorps/resources/index.md
@@ -1,3 +1,0 @@
-# Developer resources
-
-- [styleguide] (styleguide/index.html)

--- a/peacecorps/peacecorps/static/peacecorps/resources/styleguide/index.html
+++ b/peacecorps/peacecorps/static/peacecorps/resources/styleguide/index.html
@@ -10,10 +10,18 @@
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0,
+      maximum-scale=1.0, user-scalable=0">
   <meta name="viewport" content="width=device-width">
 
   <link rel="stylesheet" href="public/kss.css">
   <link rel="stylesheet" href="donation.css">
+  <link rel="stylesheet" type="text/css"
+    href="//cloud.typography.com/6638272/662206/css/fonts.css" />
+  <noscript>
+    <link href='http://fonts.googleapis.com/css?family=Lato:300,400'
+          rel='stylesheet' type='text/css'>
+  </noscript>
   
 </head>
 <body id="kss-node">
@@ -82,5 +90,20 @@ environment for visuals of the site.</p>
 
 
 <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+<script type="text/javascript">
+WebFontConfig = {
+  google: { families: [ 'Lato:300,400:latin' ] }
+};
+(function() {
+  var wf = document.createElement('script');
+  wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+    '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+  wf.type = 'text/javascript';
+  wf.async = 'true';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(wf, s);
+})();
+</script>
+
 </body>
 </html>

--- a/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-base.html
+++ b/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-base.html
@@ -10,10 +10,18 @@
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0,
+      maximum-scale=1.0, user-scalable=0">
   <meta name="viewport" content="width=device-width">
 
   <link rel="stylesheet" href="public/kss.css">
   <link rel="stylesheet" href="donation.css">
+  <link rel="stylesheet" type="text/css"
+    href="//cloud.typography.com/6638272/662206/css/fonts.css" />
+  <noscript>
+    <link href='http://fonts.googleapis.com/css?family=Lato:300,400'
+          rel='stylesheet' type='text/css'>
+  </noscript>
   
 </head>
 <body id="kss-node">
@@ -1231,5 +1239,20 @@ styled the headings.</p>
 
 
 <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+<script type="text/javascript">
+WebFontConfig = {
+  google: { families: [ 'Lato:300,400:latin' ] }
+};
+(function() {
+  var wf = document.createElement('script');
+  wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+    '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+  wf.type = 'text/javascript';
+  wf.async = 'true';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(wf, s);
+})();
+</script>
+
 </body>
 </html>

--- a/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-components.html
+++ b/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-components.html
@@ -10,10 +10,18 @@
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0,
+      maximum-scale=1.0, user-scalable=0">
   <meta name="viewport" content="width=device-width">
 
   <link rel="stylesheet" href="public/kss.css">
   <link rel="stylesheet" href="donation.css">
+  <link rel="stylesheet" type="text/css"
+    href="//cloud.typography.com/6638272/662206/css/fonts.css" />
+  <noscript>
+    <link href='http://fonts.googleapis.com/css?family=Lato:300,400'
+          rel='stylesheet' type='text/css'>
+  </noscript>
   
 </head>
 <body id="kss-node">
@@ -346,5 +354,20 @@ banner has a top line of a different color.</p>
 
 
 <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+<script type="text/javascript">
+WebFontConfig = {
+  google: { families: [ 'Lato:300,400:latin' ] }
+};
+(function() {
+  var wf = document.createElement('script');
+  wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+    '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+  wf.type = 'text/javascript';
+  wf.async = 'true';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(wf, s);
+})();
+</script>
+
 </body>
 </html>

--- a/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-modules.html
+++ b/peacecorps/peacecorps/static/peacecorps/resources/styleguide/section-modules.html
@@ -10,10 +10,18 @@
 
   <meta name="description" content="">
   <meta name="generator" content="kss-node">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0,
+      maximum-scale=1.0, user-scalable=0">
   <meta name="viewport" content="width=device-width">
 
   <link rel="stylesheet" href="public/kss.css">
   <link rel="stylesheet" href="donation.css">
+  <link rel="stylesheet" type="text/css"
+    href="//cloud.typography.com/6638272/662206/css/fonts.css" />
+  <noscript>
+    <link href='http://fonts.googleapis.com/css?family=Lato:300,400'
+          rel='stylesheet' type='text/css'>
+  </noscript>
   
 </head>
 <body id="kss-node">
@@ -89,5 +97,20 @@ of the site, such as the logo or main navigation.</p>
 
 
 <!-- Automatically generated using <a href="https://github.com/kss-node/kss-node">kss-node</a>. -->
+<script type="text/javascript">
+WebFontConfig = {
+  google: { families: [ 'Lato:300,400:latin' ] }
+};
+(function() {
+  var wf = document.createElement('script');
+  wf.src = ('https:' == document.location.protocol ? 'https' : 'http') +
+    '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+  wf.type = 'text/javascript';
+  wf.async = 'true';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(wf, s);
+})();
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
Rather then messing with gh-pages, which would require a complicated
process to keep upstream and forks in sync, this serves the styleguide
with a service called raw git: rawgit.com.

This link will always point to the main site, not the fork, which I
think is fine because you can look at that one locally.

Also added the fonts and such to the styleguide. Unfortunately,
typograhpy.com will not work because it needs to be whitelisted.
