### PR TITLE
Significantly reduce query count on sorter

### DIFF
--- a/peacecorps/peacecorps/fixtures/tests.yaml
+++ b/peacecorps/peacecorps/fixtures/tests.yaml
@@ -370,7 +370,7 @@
     account: 307-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 12
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Azerbaijan Country Fund will support Volunteer and community projects that will
       take place in Azerbaijan. These projects often focus on developing the skills
@@ -386,7 +386,7 @@
     account: 308-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 19
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Belize Country Fund will support Volunteer and community projects that will
       take place in Belize. These projects include water and sanitation, agricultural
@@ -402,7 +402,7 @@
     account: 309-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 20
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Benin Country Fund will support Volunteer and community projects in education,
       health, environment and small business. The fund also supports initiatives,
@@ -420,7 +420,7 @@
     account: 305-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 3
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Albania Country Fund will support Volunteer and community projects that will
       take place in Albania. These projects include water and sanitation, agricultural
@@ -436,7 +436,7 @@
     account: 306-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 9
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Armenia Country Fund will support Volunteer and community projects that will
       take place in Armenia. These projects include water and sanitation, agricultural
@@ -452,7 +452,7 @@
     account: 310-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 24
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Botswana Country Fund will support Volunteer and community projects that will
       take place in Botswana. These projects support reducing transmission of HIV
@@ -468,7 +468,7 @@
     account: 311-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 28
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Burkina Faso Country Fund will support Volunteer and community projects that
       will take place in Burkina Faso. These projects include water and sanitation,
@@ -484,7 +484,7 @@
     account: 312-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 32
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Cambodia Country Fund will support Volunteer and community projects that will
       take place in Cambodia. These projects include water and sanitation, agricultural
@@ -500,7 +500,7 @@
     account: 313-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 33
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Cameroon Country Fund will support Volunteer and community projects that will
       take place in Cameroon. These projects include water and sanitation, agricultural
@@ -516,7 +516,7 @@
     account: 314-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 38
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       China Country Fund will support Volunteer and community projects that will take
       place in China. These projects are largely built around the volunteer''s assignment
@@ -536,7 +536,7 @@
     account: 315-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 39
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Colombia Country Fund will support Volunteer and community projects that will
       take place in Colombia. These projects include water and sanitation, agricultural
@@ -552,7 +552,7 @@
     account: 316-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 43
     description: '{"data": [{"type": "text", "data": {"text": "Contributions made
       to the Costa Rica Country Fund will support Volunteers and their community partners
       with Children, Youth and Family; Community Economic Development; and Rural Community
@@ -576,7 +576,7 @@
     account: 317-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 51
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Dominican Republic Country Fund will support Volunteer and community projects
       that will take place in Dominican Republic. These projects include water and
@@ -592,7 +592,7 @@
     account: 318-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 53
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Ecuador Country Fund will support Volunteer and community projects that will
       take place in Ecuador. These projects support our program work in Community
@@ -609,7 +609,7 @@
     account: 319-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 55
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       El Salvador Country Fund will support Volunteer and community projects that
       will take place in El Salvador. These projects include water and sanitation,
@@ -625,7 +625,7 @@
     account: 320-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 59
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Ethiopia Country Fund will support Volunteer and community projects that will
       take place in Ethiopia. These projects include water and sanitation, agricultural
@@ -641,7 +641,7 @@
     account: 321-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 60
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Fiji Country Fund will support Volunteer and community projects that will take
       place in Fiji. These projects include water and sanitation, agricultural development,
@@ -657,7 +657,7 @@
     account: 322-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 64
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Georgia Country Fund will support Volunteer and community projects that will
       take place in Georgia. These projects include water and sanitation, agricultural
@@ -673,7 +673,7 @@
     account: 323-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 66
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Ghana Country Fund will support Volunteer and community projects that will take
       place in Ghana. These projects include water and sanitation, agricultural development,
@@ -689,7 +689,7 @@
     account: 324-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 69
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Guatemala Country Fund will support Volunteer and community projects that will
       take place in Guatemala. These projects include water and sanitation, agricultural
@@ -705,7 +705,7 @@
     account: 325-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 70
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Guinea Country Fund will support Volunteer and community projects that will
       take place in Guinea. These projects include water and sanitation, agricultural
@@ -721,7 +721,7 @@
     account: 326-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 72
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Guyana Country Fund will support Volunteer and community projects that will
       take place in Guyana. These projects include water and sanitation, agricultural
@@ -737,7 +737,7 @@
     account: 327-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 79
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Indonesia Country Fund will support Volunteer and community projects that will
       take place in Indonesia. These projects will focus on English education and
@@ -753,7 +753,7 @@
     account: 328-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 84
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Jamaica Country Fund will support Volunteer and community projects that will
       take place in Jamaica. These projects include water and sanitation, agricultural
@@ -769,7 +769,7 @@
     account: 329-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 86
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Jordan Country Fund will support Volunteer and community projects that will
       take place in Jordan. These projects include water and sanitation, agricultural
@@ -785,7 +785,7 @@
     account: 331-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 95
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Lesotho Country Fund will support Volunteer and community projects that will
       take place in Lesotho. These projects include water and sanitation, agricultural
@@ -801,7 +801,7 @@
     account: 332-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 96
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Liberia Country Fund will support Volunteer and community projects that will
       take place in Liberia. These projects include secondary education and HIV/AIDS
@@ -817,7 +817,7 @@
     account: 333-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 101
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Macedonia Country Fund will support Volunteer and community projects that will
       take place in Macedonia. These projects include water and sanitation, agricultural
@@ -833,7 +833,7 @@
     account: 334-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 102
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Madagascar Country Fund will support Volunteer and community projects that will
       take place in Madagascar. These projects include water and sanitation, agricultural
@@ -849,7 +849,7 @@
     account: 335-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 103
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Malawi Country Fund will support many varied Volunteer projects in Malawi. Malawi
       is one of the poorest countries in the world. Malawi is one of the poorest countries
@@ -876,7 +876,7 @@
     account: 336-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 111
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Mexico Country Fund will support Volunteer and community projects that will
       take place in Mexico. These projects include water and sanitation, agricultural
@@ -892,7 +892,7 @@
     account: 337-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 112
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Micronesia Country Fund will support Volunteer and community projects that will
       take place in Micronesia. These projects include water and sanitation, agricultural
@@ -908,7 +908,7 @@
     account: 338-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 113
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Moldova Country Fund will support Volunteer and community projects that will
       take place in Moldova. These projects include water and sanitation, agricultural
@@ -924,7 +924,7 @@
     account: 339-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 116
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Mongolia Country Fund will support Volunteer and community projects that will
       take place in Mongolia. These projects include water and sanitation, agricultural
@@ -940,7 +940,7 @@
     account: 340-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 117
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Morocco Country Fund will support Volunteer and community projects that will
       take place in Morocco. These projects include water and sanitation, agricultural
@@ -956,7 +956,7 @@
     account: 341-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 118
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Mozambique Country Fund will support Volunteer and community projects that will
       take place in Mozambique. These projects include water and sanitation, agricultural
@@ -972,7 +972,7 @@
     account: 342-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 119
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Namibia Country Fund will support Volunteer and community projects that will
       take place in Namibia. These projects include water and sanitation, agricultural
@@ -988,7 +988,7 @@
     account: 343-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 121
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Nepal Country Fund will support approved Volunteer and community PCPP projects
       that will take place in Nepal. Volunteer projects typically focus on food security
@@ -1006,7 +1006,7 @@
     account: 344-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 125
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Nicaragua Country Fund will support Volunteer and community projects that will
       take place in Nicaragua. These projects include water and sanitation, agricultural
@@ -1022,7 +1022,7 @@
     account: 345-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 133
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Panama Country Fund will support Volunteers and their community partners to
       implement on-going development projects in one of our 5 programs: Sustainable
@@ -1044,7 +1044,7 @@
     account: 346-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 135
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Paraguay Country Fund will support Volunteer and community projects that will
       take place in Paraguay. These projects include water and sanitation, agricultural
@@ -1060,7 +1060,7 @@
     account: 347-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 136
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Peru Country Fund will support Volunteer and community projects that will take
       place in Peru. These projects include water and sanitation, agricultural development,
@@ -1076,7 +1076,7 @@
     account: 348-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 137
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Philippines Country Fund will support Volunteer and community projects in the
       Philippines.These development projects include, but are not limited to the following:
@@ -1094,7 +1094,7 @@
     account: 349-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 143
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Rwanda Country Fund will support Volunteer and community projects that will
       take place in Rwanda. These projects include water and sanitation, agricultural
@@ -1110,7 +1110,7 @@
     account: 350-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 147
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Samoa Country Fund will support Volunteer and community projects that will take
       place in Samoa. These projects include water and sanitation, agricultural development,
@@ -1126,7 +1126,7 @@
     account: 351-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 151
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Senegal Country Fund will support Volunteer and community projects that will
       take place in Senegal. These projects include water and sanitation, agricultural
@@ -1142,7 +1142,7 @@
     account: 352-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 154
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Sierra Leone Country Fund will support Volunteer and community projects that
       will take place in Sierra Leone. These projects will focus on English education
@@ -1158,7 +1158,7 @@
     account: 353-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 160
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       South Africa Country Fund will support Volunteer and community projects that
       will take place in South Africa. These projects include water and sanitation,
@@ -1174,7 +1174,7 @@
     account: 354-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 165
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Swaziland Country Fund will support Volunteer and community projects that will
       take place in Swaziland. These projects include water and sanitation, agricultural
@@ -1190,7 +1190,7 @@
     account: 355-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 170
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Tanzania Country Fund will support Volunteer and community projects that will
       take place in Tanzania. These projects include water and sanitation, agricultural
@@ -1206,7 +1206,7 @@
     account: 356-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 171
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Thailand Country Fund will support Volunteer and community projects that will
       take place in Thailand. These projects include water and sanitation, agricultural
@@ -1222,7 +1222,7 @@
     account: 357-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 172
     description: '{"data":[{"type":"text","data":{"text":"Contributions to the Togo
       Country Fund will support Volunteer and community projects that will take place
       in Togo. These projects include water and sanitation, agricultural development,
@@ -1238,7 +1238,7 @@
     account: 358-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 173
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Tonga Country Fund will support Volunteer and community projects that will take
       place in Tonga.These projects include youth development, school library development,
@@ -1254,7 +1254,7 @@
     account: 359-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 179
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Uganda Country Fund will support Volunteer and community projects that will
       take place in Uganda. These projects include water and sanitation, agricultural
@@ -1270,7 +1270,7 @@
     account: 360-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 180
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Ukraine Country Fund will support Volunteer and community projects that will
       take place in Ukraine. These projects include water and sanitation, agricultural
@@ -1286,7 +1286,7 @@
     account: 361-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 185
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Vanuatu Country Fund will support Volunteer and community projects that will
       take place in Vanuatu. These projects include water and sanitation, agricultural
@@ -1302,7 +1302,7 @@
     account: 362-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 189
     description: '{"data": [{"type": "text", "data": {"text": "Contributions to the
       Zambia Country Fund will support Volunteer and community projects that will
       take place in Zambia. These projects include water and sanitation, agricultural
@@ -1318,7 +1318,7 @@
     account: 330-CFD
     call: null
     campaigntype: coun
-    country: null
+    country: 88
     description: '{"data": [{"type": "text", "data": {"text": "<p>Contributions to
       the Kenya Country Fund will support Volunteer Community projects in Kenya. The
       scope of projects to be funded would likely fall within education, water/sanitation,

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -113,12 +113,10 @@ class Account(models.Model):
     def total_donated(self):
         """Total amount raised via donations (including real-time). Does not
         include community contributions"""
-        if hasattr(self, 'dynamic_total'):
-            dynamic_total = self.dynamic_total or 0
-        else:
+        if not hasattr(self, 'dynamic_total'):
             agg = self.donations.aggregate(Sum('amount'))
-            dynamic_total = agg['amount__sum'] or 0
-        return self.current + dynamic_total
+            self.dynamic_total = agg['amount__sum']
+        return self.current + (self.dynamic_total or 0)
 
     def total_raised(self):
         """Total amount raised, including donations and community

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -37,7 +37,7 @@
   <ul class="js-filterable u-unmarked_list u-clearfix" id="issue"
       data-filter-type="issue">
   {% for issue in issues %}
-    {% set issue_projects = issue.projects() %}
+    {% set issue_projects = projects_by_issue[issue.id] %}
     <li id="page-issue-{{ issue.id }}">
       <a href="#" aria-controls="collapsible-page-issue-{{ issue.id }}"
           class="js-pageNav section section--neutral_medium bordered bordered--row

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -2,7 +2,9 @@ import json
 from urllib.parse import quote as urlquote
 
 from django.core.urlresolvers import reverse
-from django.test import Client, TestCase
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.test import Client, TestCase, TransactionTestCase
+from django.test.utils import CaptureQueriesContext
 
 from peacecorps.models import Account, Campaign, Country, FAQ, Issue, Project
 
@@ -378,6 +380,18 @@ class DonatePagesTests(TestCase):
         response = self.client.get(url, HTTP_HOST='example.com')
         self.assertContains(response, 'Thank you, Billy')
         self.assertContains(response, urlquote('http://example.com/'))
+
+
+class QueryCoundTests(TransactionTestCase):
+    fixtures = ['tests', 'countries', 'issues']
+
+    def test_sorter_query_count(self):
+        """Place an upper bounds on the number of queries that can be present
+        on the sorter page"""
+        with CaptureQueriesContext(connections[DEFAULT_DB_ALIAS]) as cap:
+            self.client.get(reverse('donate projects funds'))
+            # We're currently at 8
+            self.assertTrue(len(cap) < 10)
 
 
 class FAQTests(TestCase):

--- a/peacecorps/peacecorps/tests/test_views.py
+++ b/peacecorps/peacecorps/tests/test_views.py
@@ -382,7 +382,7 @@ class DonatePagesTests(TestCase):
         self.assertContains(response, urlquote('http://example.com/'))
 
 
-class QueryCoundTests(TransactionTestCase):
+class QueryCountTests(TransactionTestCase):
     fixtures = ['tests', 'countries', 'issues']
 
     def test_sorter_query_count(self):

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -1,3 +1,4 @@
+# @todo split into smaller files; remove "donate_" prefix
 from collections import defaultdict
 from urllib.parse import quote as urlquote
 
@@ -151,6 +152,7 @@ def donate_projects_funds(request):
     """
     The page that displays a sorter for all projects, issues, volunteers.
     """
+    # @todo - hide some of the prefetching logic?
     countries = Campaign.objects.prefetch_related('country').filter(
         campaigntype=Campaign.COUNTRY).order_by('country__name')
     issues = Issue.objects.prefetch_related('campaigns').order_by('name')
@@ -159,6 +161,8 @@ def donate_projects_funds(request):
         'campaigns',
         'country',
     ).order_by('volunteername')
+    # Before we can build projects_by_issue, we need to know which funds are
+    # associated with which issues
     issues_by_campaign = defaultdict(list)
     for issue in issues:
         for campaign in issue.campaigns.all():

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -160,6 +160,7 @@ def donate_projects_funds(request):
         Prefetch('account', queryset=Account.objects.all()),
         'campaigns',
         'country',
+        'volunteerpicture'
     ).order_by('volunteername')
     # Before we can build projects_by_issue, we need to know which funds are
     # associated with which issues


### PR DESCRIPTION
We were executing multiple summations and country lookups for each project. As this is a listing page, prefetch as much of those related objects as possible. We now will almost always include an account's dynamic sum total sum when fetching it from the db.

This also adds a test for the upper limit on the number of queries on the sorter page, so we know when/if we break this in the future.
