### PR TITLE
Gzip the cache -- we've got some very large pages

### DIFF
--- a/peacecorps/peacecorps/cache.py
+++ b/peacecorps/peacecorps/cache.py
@@ -4,9 +4,9 @@ from django.views.decorators.cache import cache_page
 
 def midterm_cache(*args, **kwargs):
     return cache_page(settings.CACHES['midterm']['TIMEOUT'],
-                      cache='midterm')(*args, **kwargs)
+                      cache='zipped_midterm')(*args, **kwargs)
 
 
 def shortterm_cache(*args, **kwargs):
     return cache_page(settings.CACHES['shortterm']['TIMEOUT'],
-                      cache='shortterm')(*args, **kwargs)
+                      cache='zipped_shortterm')(*args, **kwargs)

--- a/peacecorps/peacecorps/settings/base.py
+++ b/peacecorps/peacecorps/settings/base.py
@@ -87,10 +87,18 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     },
+    'zipped_shortterm': {
+        'BACKEND': 'django_gzipping_cache.cache.GzippingCache',
+        'LOCATION': 'shortterm',
+    },
     'shortterm': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
         'TIMEOUT': 60*5,    # 5 minutes
         'KEY_PREFIX': 'shortterm',
+    },
+    'zipped_midterm': {
+        'BACKEND': 'django_gzipping_cache.cache.GzippingCache',
+        'LOCATION': 'midterm',
     },
     'midterm': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ django-admin-sortable2
 -e git://github.com/gusdan/django-elasticache.git#egg=django-elasticache
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
 -e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages
+# Fixes an upstream bug. See https://github.com/mapmyfitness/django-gzipping-cache/pull/1
+-e git+https://github.com/18f/django-gzipping-cache.git#egg=django-gzipping-cache


### PR DESCRIPTION
Adds a gzip step to caching, which should allow us to use elasticache now, before we reduce page size.
