### PR TITLE
Updated Abstract Presentation

### DIFF
--- a/peacecorps/peacecorps/migrations/0005_auto_20150224_0300.py
+++ b/peacecorps/peacecorps/migrations/0005_auto_20150224_0300.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0004_featuredcampaign_image'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='campaign',
+            name='abstract',
+            field=models.TextField(blank=True, null=True, max_length=256),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -67,7 +67,7 @@ class AbstractHTMLMixin(object):
             for block in json.loads(self.description)['data']:
                 if block.get('type') == 'text':
                     data = block['data']
-                    # Naive string shortener 
+                    # Naive string shortener
                     if len(data['text']) > settings.ABSTRACT_LENGTH:
                         trimmed = data['text'][:settings.ABSTRACT_LENGTH]
                         trimmed = trimmed[:trimmed.rindex(' ')]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -57,7 +57,7 @@ class AbstractHTMLMixin(object):
     assumes that the object has a primary_url method (for the read-more
     link)."""
 
-    def abstract_html(self):
+    def abstract_html(self, **kwargs):
         """If an explicit abstract is present, return it. Otherwise, return
         the formatted first paragraph of the description"""
         context = {'text': ''}
@@ -67,13 +67,18 @@ class AbstractHTMLMixin(object):
             for block in json.loads(self.description)['data']:
                 if block.get('type') == 'text':
                     data = block['data']
-                    # Naive string shortener
+                    # Naive string shortener 
                     if len(data['text']) > settings.ABSTRACT_LENGTH:
                         trimmed = data['text'][:settings.ABSTRACT_LENGTH]
                         trimmed = trimmed[:trimmed.rindex(' ')]
                         context['text'] = trimmed
                         context['shortened'] = True
                         context['more_url'] = self.primary_url()
+                        try:
+                            if kwargs['read_more_link'] is False:
+                                context['read_more_link'] = False
+                        except KeyError:
+                            context['read_more_link'] = True
                     else:
                         context['text'] = data['text']
                     break

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -231,7 +231,7 @@ class Campaign(models.Model, AbstractHTMLMixin):
     featuredprojects = models.ManyToManyField('Project', blank=True, null=True)
     country = models.ForeignKey(
         'Country', related_name="campaign", blank=True, null=True, unique=True)
-    abstract = models.TextField(blank=True, null=True)
+    abstract = models.TextField(blank=True, null=True, max_length=256)
 
     # Unlike projects, funds start published
     published = models.BooleanField(default=True)

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -73,7 +73,7 @@ class AbstractHTMLMixin(object):
                         trimmed = trimmed[:trimmed.rindex(' ')]
                         context['text'] = trimmed
                         context['shortened'] = True
-                        if read_more_link is True:
+                        if read_more_link:
                             context['more_url'] = self.primary_url()
                     else:
                         context['text'] = data['text']

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -57,7 +57,7 @@ class AbstractHTMLMixin(object):
     assumes that the object has a primary_url method (for the read-more
     link)."""
 
-    def abstract_html(self, **kwargs):
+    def abstract_html(self, read_more_link=False):
         """If an explicit abstract is present, return it. Otherwise, return
         the formatted first paragraph of the description"""
         context = {'text': ''}
@@ -73,12 +73,8 @@ class AbstractHTMLMixin(object):
                         trimmed = trimmed[:trimmed.rindex(' ')]
                         context['text'] = trimmed
                         context['shortened'] = True
-                        context['more_url'] = self.primary_url()
-                        try:
-                            if kwargs['read_more_link'] is False:
-                                context['read_more_link'] = False
-                        except KeyError:
-                            context['read_more_link'] = True
+                        if read_more_link is True:
+                            context['more_url'] = self.primary_url()
                     else:
                         context['text'] = data['text']
                     break

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -195,7 +195,7 @@
         {{ campaign.name }}
       </a>
     </h3>
-    {{ campaign.abstract_html()|safe }}
+    {{ campaign.abstract_html(read_more_link=True)|safe }}
     <a class="button button--sm button--primary"
        href="{{ url("donate campaign", slug=campaign.slug) }}#amount-form">
       Give to this fund</a>

--- a/peacecorps/peacecorps/templates/donations/donate_all.jinja
+++ b/peacecorps/peacecorps/templates/donations/donate_all.jinja
@@ -296,7 +296,7 @@
         </a>
       </h2>
       <p>
-        {{ project.abstract_html()|safe }}
+        {{ project.abstract_html(read_more_link=True)|safe }}
       </p>
 
       {# TODO make macro #}

--- a/peacecorps/peacecorps/templates/donations/includes/abstract.html
+++ b/peacecorps/peacecorps/templates/donations/includes/abstract.html
@@ -1,7 +1,11 @@
 {% load sirtrevor %}
 <div class="content-block text-block">
   {% if shortened %}
-    {{ text|add:" ..."|markdown }}
+	{% if not read_more_link %}
+	  {{ text|add:" ..."|markdown }}
+	{% else %}
+	  {{ text|add:" ..."|add:"([read more]("|add:more_url|add:"))"|markdown }}
+	{% endif %}
   {% else %}
     {{ text|markdown }}
   {% endif %}

--- a/peacecorps/peacecorps/templates/donations/includes/abstract.html
+++ b/peacecorps/peacecorps/templates/donations/includes/abstract.html
@@ -1,10 +1,10 @@
 {% load sirtrevor %}
 <div class="content-block text-block">
   {% if shortened %}
-	{% if not read_more_link %}
-	  {{ text|add:" ..."|markdown }}
-	{% else %}
+	{% if more_url %}
 	  {{ text|add:" ..."|add:"([read more]("|add:more_url|add:"))"|markdown }}
+	{% else %}
+	  {{ text|add:" ..."|markdown }}
 	{% endif %}
   {% else %}
     {{ text|markdown }}

--- a/peacecorps/peacecorps/templates/donations/includes/abstract.html
+++ b/peacecorps/peacecorps/templates/donations/includes/abstract.html
@@ -1,7 +1,7 @@
 {% load sirtrevor %}
 <div class="content-block text-block">
   {% if shortened %}
-    {{ text|add:" ..."|add:"([read more]("|add:more_url|add:"))"|markdown }}
+    {{ text|add:" ..."|markdown }}
   {% else %}
     {{ text|markdown }}
   {% endif %}

--- a/peacecorps/peacecorps/templates/donations/landing.jinja
+++ b/peacecorps/peacecorps/templates/donations/landing.jinja
@@ -101,7 +101,7 @@
               {% else %}Help this Project{% endif %}
             </a>
           </h3>
-          <p class="">{{ project.abstract_html()|safe }}</p>
+          <p class="">{{ project.abstract_html(read_more_link=False)|safe }}</p>
           <a class="t-single_nav t-nom"
               href="{{url("donate project", slug=project.slug)}}">
             Read Their Story

--- a/peacecorps/peacecorps/tests/test_models.py
+++ b/peacecorps/peacecorps/tests/test_models.py
@@ -182,6 +182,7 @@ class ProjectTests(TestCase):
         self.assertTrue(len(proj.abstract_html()) < 400)
         self.assertTrue("..." in proj.abstract_html())
         self.assertTrue(proj.slug in proj.abstract_html())
+        self.assertFalse("read more" in proj.abstract_html(read_more_link=False))
 
         proj.abstract = "This is the abstract"
         self.assertTrue("This is the abstract" in proj.abstract_html())

--- a/peacecorps/peacecorps/tests/test_models.py
+++ b/peacecorps/peacecorps/tests/test_models.py
@@ -181,8 +181,8 @@ class ProjectTests(TestCase):
         # The text has been shortened, but markup's been added
         self.assertTrue(len(proj.abstract_html()) < 400)
         self.assertTrue("..." in proj.abstract_html())
-        self.assertTrue(proj.slug in proj.abstract_html())
-        self.assertFalse("read more" in proj.abstract_html(read_more_link=False))
+        self.assertTrue(proj.slug in proj.abstract_html(read_more_link=True))
+        self.assertFalse("read more" in proj.abstract_html())
 
         proj.abstract = "This is the abstract"
         self.assertTrue("This is the abstract" in proj.abstract_html())


### PR DESCRIPTION
This PR implements the following
- Removes the '(read more)' text following abstracts
- Places a limit of 256 characters on abstract fields to ensure they don't extend beyond the allowed length on Featured Project highlights.
