### PR TITLE
Resolve several import warnings

### DIFF
--- a/peacecorps/peacecorps/fixtures/issues.yaml
+++ b/peacecorps/peacecorps/fixtures/issues.yaml
@@ -288,3 +288,7 @@
     campaign: 71
   model: peacecorps.sectormapping
   pk: Malaria Prevention
+- fields:
+    campaign: 66
+  model: peacecorps.sectormapping
+  pk: Health


### PR DESCRIPTION
- Allow the "None" value in sector to indicate that the project should not be associated with a sector fund
- Add a mapping between "Health" and the appropriate campaign

Note that the latter will need to be added manually to the db (to avoid overwriting existing data)
