### PR TITLE
Always use HTTPS for includes

### DIFF
--- a/peacecorps/peacecorps/settings/production.py
+++ b/peacecorps/peacecorps/settings/production.py
@@ -33,8 +33,8 @@ if MEMCACHED_URL:
 JINJA2_CONSTANTS['ANALYTICS_ID'] = 'UA-17096306-6'
 
 # Note that MEDIA_ROOT is not needed since we're using S3
-MEDIA_URL = '//{:s}.s3.amazonaws.com/'.format(os.environ.get('AWS_MEDIA_BUCKET_NAME', 'pc-media-dev'))
-STATIC_URL = '//{:s}.s3.amazonaws.com/'.format(os.environ.get('AWS_STATIC_BUCKET_NAME', 'pc-theme-dev'))
+MEDIA_URL = 'https://{:s}.s3.amazonaws.com/'.format(os.environ.get('AWS_MEDIA_BUCKET_NAME', 'pc-media-dev'))
+STATIC_URL = 'https://{:s}.s3.amazonaws.com/'.format(os.environ.get('AWS_STATIC_BUCKET_NAME', 'pc-theme-dev'))
 
 GNUPG_HOME = os.environ.get('GNUPG_HOME', '')
 GPG_RECIPIENTS = {

--- a/peacecorps/peacecorps/templates/donations/base.jinja
+++ b/peacecorps/peacecorps/templates/donations/base.jinja
@@ -16,7 +16,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:description" content="{% block og_description %}Peace Corps Volunteers help build clinics in villages, put books in schools, and improve access to nutritious food. Give today and help support projects like these.{% endblock %}" />
     <meta property="og:image" content="{{ static('peacecorps/img/og_default.jpg') }}" />
-    
+
     {% if MINIFIED %}
     <link rel="stylesheet" href="{{ static(
         "peacecorps/css/compiled/donation.min.css") }}" />
@@ -25,7 +25,7 @@
         "peacecorps/css/compiled/donation.css") }}" />
     {% endif %}
     <link rel="stylesheet" type="text/css"
-        href="//cloud.typography.com/6638272/662206/css/fonts.css" />
+        href="https://cloud.typography.com/6638272/662206/css/fonts.css" />
     <link rel="icon" type="image/x-icon" href="{{ static("favicon.ico") }}" />
     <noscript>
       <link rel="stylesheet" type="text/css"


### PR DESCRIPTION
There's no reason to use protocol-relative includes for assets. We can safely default to always using https. This also fixes some errors using protocol-relative URLs with opengraph tags.
