### PR TITLE
Shrink headers in the footer to match lgl

### DIFF
--- a/peacecorps/peacecorps/templates/donations/base.jinja
+++ b/peacecorps/peacecorps/templates/donations/base.jinja
@@ -167,7 +167,7 @@
         <p class="t-body--md">Full site, all links return to peacecorps.gov</p>
         <hr class="separator--h" />
         <nav class="column nested_column--fourth sub_nav sub_nav--vertical">
-          <h3 class="t-title--2 t--gray--2">Join</h3>
+          <h3 class="t-title--3 t--gray--2">Join</h3>
           <ul class="u-unmarked_list">
             <li class="sub_nav__link">
               <a href="http://www.peacecorps.gov/apply/?from=applyby">Apply</a>
@@ -187,7 +187,7 @@
           </ul>
         </nav>
         <nav class="column nested_column--fourth sub_nav sub_nav--vertical">
-          <h3 class="t-title--2 t--gray--2">Resources</h3>
+          <h3 class="t-title--3 t--gray--2">Resources</h3>
           <ul class="u-unmarked_list">
             <li class="sub_nav__link">
               <a href="http://www.peacecorps.gov/resources/returned/home/">
@@ -203,7 +203,7 @@
           </ul>
         </nav>
         <nav class="column nested_column_half sub_nav sub_nav--vertical">
-          <h3 class="t-title--2 t--gray--2">Contact</h3>
+          <h3 class="t-title--3 t--gray--2">Contact</h3>
           <ul class="u-unmarked_list">
             <li class="sub_nav__link sub_nav__link--condensed">Peace Corps<br>
               Paul D. Coverdell Peace Corps Headquarters<br>


### PR DESCRIPTION
LGL uses a single size for all of the header text in the footer. Do the same for donations, which resolves a small-width problem.
## ![screen shot 2015-03-03 at 12 14 50 am](https://cloud.githubusercontent.com/assets/326918/6456918/94ffb114-c13a-11e4-8862-93fc80c779d3.png)

![screen shot 2015-03-03 at 12 15 01 am](https://cloud.githubusercontent.com/assets/326918/6456917/94fee9c8-c13a-11e4-952e-51eb730846cd.png)
