### PR TITLE
Participate in the Digital Analytics Program

### DIFF
--- a/peacecorps/peacecorps/templates/donations/base.jinja
+++ b/peacecorps/peacecorps/templates/donations/base.jinja
@@ -284,6 +284,10 @@ WebFontConfig = {
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 </script>
+
+<!-- This is all it takes to report an agency's traffic to the DAP. -->
+<script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
+
 {% endif %}
 
 {% block custom_js %}{% endblock %}


### PR DESCRIPTION
This adds a snippet that links to the DAP. It's put inside the same conditional block as the main GA snippet, on the assumption that an `ANALYTICS_ID` will always/only be present on production.

The URL to the snippet may need to be updated down the line, but right now there is no official public central hosting location for the DAP snippet.
