### PR TITLE
Add a separate field for featured projects' front page images

### DIFF
--- a/peacecorps/peacecorps/fixtures/tests.yaml
+++ b/peacecorps/peacecorps/fixtures/tests.yaml
@@ -2213,16 +2213,16 @@
 - fields: {code: IRN, name: Iran}
   model: peacecorps.country
   pk: 192
-- fields: {project: 14-684-020}
+- fields: {project: 14-684-020, image: 8}
   model: peacecorps.featuredprojectfrontpage
   pk: 4
-- fields: {project: 15-527-002}
+- fields: {project: 15-527-002, image: 9}
   model: peacecorps.featuredprojectfrontpage
   pk: 5
-- fields: {project: 14-524-007}
+- fields: {project: 14-524-007, image: 10}
   model: peacecorps.featuredprojectfrontpage
   pk: 6
-- fields: {project: 14-693-016}
+- fields: {project: 14-693-016, image: 11}
   model: peacecorps.featuredprojectfrontpage
   pk: 7
 - fields: {caption: 'Water buffalo pulling a plow in Indonesia. Photo by wikipedia

--- a/peacecorps/peacecorps/migrations/0006_featuredprojectfrontpage_image.py
+++ b/peacecorps/peacecorps/migrations/0006_featuredprojectfrontpage_image.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def copy_image(apps, schema_editor):
+    Featured = apps.get_model("peacecorps", "FeaturedProjectFrontPage")
+    for featured in Featured.objects.filter(
+            project__featured_image__isnull=False):
+        featured.image = featured.project.featured_image
+        featured.save()
+
+
+def delete_image(apps, schema_editor):
+    Featured = apps.get_model("peacecorps", "FeaturedProjectFrontPage")
+    Featured.objects.all().update(image=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0005_auto_20150224_0300'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='featuredprojectfrontpage',
+            name='image',
+            field=models.ForeignKey(
+                null=True, to='peacecorps.Media',
+                help_text='Image shown on the landing page. Roughly 525x320'),
+            preserve_default=True,
+        ),
+        migrations.RunPython(copy_image, delete_image),
+        migrations.AlterField(
+            model_name='featuredprojectfrontpage',
+            name='image',
+            field=models.ForeignKey(
+                to='peacecorps.Media',
+                help_text='Image shown on the landing page. Roughly 525x320'),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -314,6 +314,8 @@ class FeaturedCampaign(models.Model):
 class FeaturedProjectFrontPage(models.Model):
     project = models.ForeignKey('Project', to_field='account',
                                 limit_choices_to={'published': True})
+    image = models.ForeignKey(
+        'Media', help_text='Image shown on the landing page. Roughly 525x320')
 
     class Meta:
         verbose_name = 'Featured Project'

--- a/peacecorps/peacecorps/templates/donations/landing.jinja
+++ b/peacecorps/peacecorps/templates/donations/landing.jinja
@@ -75,11 +75,12 @@
   <section class="section__content section__content--lg
       full_banner full_banner--neutral">
     <h1 id="featured" class="t-title--1">Featured Projects</h1>
-    {% for project in featuredprojects %}
+    {% for featured in featuredprojects %}
+      {% set project=featured.project %}
       <article class="section__box section--white u-clearfix">
         <div class="column nested_column--lg_greater_half
             u-clearfix u-hv_center--block">
-          <img src="{{ project.featured_image.url }}"
+          <img src="{{ featured.image.url }}"
             style="width: 100%; height: auto" />
           <a href="{{ url("donate project", slug=project.slug) }}"
                class="button button--sm button--primary

--- a/peacecorps/peacecorps/views.py
+++ b/peacecorps/peacecorps/views.py
@@ -100,10 +100,8 @@ def donation_payment(request, account, project=None, campaign=None):
 
 def donate_landing(request):
     """First page for the donations section"""
-    featuredprojects = list(map(
-        lambda fp: fp.project,
-        FeaturedProjectFrontPage.objects.select_related(
-            'project__featured_image')))
+    featuredprojects = FeaturedProjectFrontPage.objects.select_related(
+        'project', 'image')
     projects = Project.published_objects.select_related('country', 'account')
 
     featuredcampaign = FeaturedCampaign.objects.filter(pk=1).first()


### PR DESCRIPTION
Also migrates over existing headers so that there should be no discontinuity in production. Tested the migration locally.
