### PR TITLE
Help Text Additions

### DIFF
--- a/peacecorps/peacecorps/__init__.py
+++ b/peacecorps/peacecorps/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'peacecorps.apps.PeaceCorpsConfig'

--- a/peacecorps/peacecorps/apps.py
+++ b/peacecorps/peacecorps/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class PeaceCorpsConfig(AppConfig):
+    name = 'peacecorps'
+    verbose_name = "Peace Corps"

--- a/peacecorps/peacecorps/migrations/0007_auto_20150313_1609.py
+++ b/peacecorps/peacecorps/migrations/0007_auto_20150313_1609.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0006_featuredprojectfrontpage_image'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='account',
+            name='category',
+            field=models.CharField(max_length=10, choices=[('coun', 'Country'), ('sec', 'Sector'), ('mem', 'Memorial'), ('oth', 'Other'), ('proj', 'Project')], help_text='The type of         account.'),
+        ),
+        migrations.AlterField(
+            model_name='account',
+            name='code',
+            field=models.CharField(max_length=25, serialize=False, primary_key=True, help_text='The accounting code for the project or fund.'),
+        ),
+        migrations.AlterField(
+            model_name='account',
+            name='community_contribution',
+            field=models.IntegerField(blank=True, null=True, help_text='For PCPP projects, the amount of community contributions,         in cents.'),
+        ),
+        migrations.AlterField(
+            model_name='account',
+            name='current',
+            field=models.IntegerField(default=0, help_text='Amount from donations (excluding real-time contributions),         in cents.'),
+        ),
+        migrations.AlterField(
+            model_name='account',
+            name='goal',
+            field=models.IntegerField(blank=True, null=True, help_text='For PCPP projects, the funding goal, excluding community         contribution.'),
+        ),
+        migrations.AlterField(
+            model_name='account',
+            name='name',
+            field=models.CharField(unique=True, max_length=120, help_text='The name of the project or fund.'),
+        ),
+    ]

--- a/peacecorps/peacecorps/migrations/0008_auto_20150313_1810.py
+++ b/peacecorps/peacecorps/migrations/0008_auto_20150313_1810.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import peacecorps.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0007_auto_20150313_1609'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='campaign',
+            name='abstract',
+            field=models.TextField(help_text='A shorter description, used for quick views of the         campaign.', blank=True, null=True, max_length=256),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='account',
+            field=models.ForeignKey(help_text='The accounting code for this campaign.', to='peacecorps.Account', unique=True),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='call',
+            field=models.CharField(help_text='If the campaign is featured on the home         page, this text is used in the button as a Call to Action.', blank=True, null=True, max_length=50),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='campaigntype',
+            field=models.CharField(help_text='The type of campaign.', verbose_name='Campaign Type', choices=[('coun', 'Country'), ('gen', 'General'), ('sec', 'Sector'), ('mem', 'Memorial'), ('oth', 'Other')], max_length=10),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='country',
+            field=models.ForeignKey(related_name='campaign', null=True, help_text='If the campaign is related to a specific country, the ID         of that country.', unique=True, to='peacecorps.Country', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='description',
+            field=peacecorps.fields.BraveSirTrevorField(help_text='A rich text description.         of the campaign.'),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='featured_image',
+            field=models.ForeignKey(related_name='campaign-headers', null=True, help_text='A large landscape image for use at the top of the campaign         page. Should be 1100px wide and 454px tall.', to='peacecorps.Media', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='icon',
+            field=models.ForeignKey(related_name='campaign-icons', verbose_name='Memorial Fund Volunteer Image', null=True, help_text='Used for Memorial Funds. Typically a picture of the         volunteer. Should be 120px tall and 120px wide, with the focus of the         photo centered.', to='peacecorps.Media', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='name',
+            field=models.CharField(help_text='The title for the associated campaign.', max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='published',
+            field=models.BooleanField(help_text='If published,         the project will be publicly visible on the site.', default=True),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='slug',
+            field=models.SlugField(help_text='Auto-generated. Used for the campaign page URL.', unique=True, max_length=120),
+        ),
+        migrations.AlterField(
+            model_name='campaign',
+            name='tagline',
+            field=models.CharField(help_text='If the campaign is featured on the home page, this text is         used as the description of the campaign.', blank=True, null=True, max_length=140),
+        ),
+    ]

--- a/peacecorps/peacecorps/migrations/0009_auto_20150313_1852.py
+++ b/peacecorps/peacecorps/migrations/0009_auto_20150313_1852.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import peacecorps.util.svg
+import peacecorps.fields
+import localflavor.us.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0008_auto_20150313_1810'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='faq',
+            options={'verbose_name': 'FAQ', 'verbose_name_plural': 'FAQs', 'ordering': ('order',)},
+        ),
+        migrations.AlterField(
+            model_name='faq',
+            name='answer',
+            field=peacecorps.fields.BraveSirTrevorField(help_text='The rich text answer to the         question.'),
+        ),
+        migrations.AlterField(
+            model_name='faq',
+            name='question',
+            field=models.CharField(max_length=256, help_text='The question used         as the prompt for the FAQ.'),
+        ),
+        migrations.AlterField(
+            model_name='faq',
+            name='slug',
+            field=models.SlugField(null=True, help_text='The URL this         should exist at.', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='featuredcampaign',
+            name='campaign',
+            field=models.ForeignKey(help_text='The campaign to feature.', to_field='account', to='peacecorps.Campaign'),
+        ),
+        migrations.AlterField(
+            model_name='featuredcampaign',
+            name='image',
+            field=models.ForeignKey(help_text='Image shown on the landing page. 1100px         wide by 475px tall.', to='peacecorps.Media'),
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='campaigns',
+            field=models.ManyToManyField(verbose_name='Sector Funds', to='peacecorps.Campaign', help_text='Sector funds to associate as being under this campaign.'),
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='icon',
+            field=models.FileField(validators=[peacecorps.util.svg.full_validation], help_text='An SVG file used to represent the issue.', upload_to='icons'),
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='icon_background',
+            field=models.FileField(help_text='The background image to use behind the SVG icon. Should be         237px by 237px.', upload_to=''),
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='name',
+            field=models.CharField(max_length=120, help_text='The name of the issue.'),
+        ),
+        migrations.AlterField(
+            model_name='media',
+            name='country',
+            field=models.ForeignKey(null=True, help_text='The country the photo was taken in.', blank=True, to='peacecorps.Country'),
+        ),
+        migrations.AlterField(
+            model_name='media',
+            name='description',
+            field=models.TextField(help_text="Provide an image description for users with screenreaders.         If the image has text, transcribe the text here. If it's a image,         briefly describe what it depicts. Do not use HTML formatting."),
+        ),
+        migrations.AlterField(
+            model_name='media',
+            name='mediatype',
+            field=models.CharField(verbose_name='Media Type', max_length=3, default='IMG', choices=[('IMG', 'Image'), ('VID', 'Video'), ('AUD', 'Audio'), ('OTH', 'Other')]),
+        ),
+        migrations.AlterField(
+            model_name='media',
+            name='transcript',
+            field=models.TextField(null=True, help_text='If the media is a video or audio recording, transcribe it         for users with disabilities.', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='abstract',
+            field=models.TextField(null=True, help_text='A shorter description, used for quick views of the         project.', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='account',
+            field=models.ForeignKey(help_text='The accounting code for the project.', to='peacecorps.Account', unique=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='campaigns',
+            field=models.ManyToManyField(null=True, help_text='The campaigns this project is related to.', to='peacecorps.Campaign', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='country',
+            field=models.ForeignKey(to='peacecorps.Country', help_text='The country the project is located in.', related_name='projects'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='description',
+            field=peacecorps.fields.BraveSirTrevorField(help_text='A rich text description         of the project..'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='featured_image',
+            field=models.ForeignKey(null=True, help_text='A large landscape image for use on the project page.         Should be 1100px wide and 454px tall.', blank=True, to='peacecorps.Media'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='overflow',
+            field=models.ForeignKey(null=True, help_text="The fund donors will be encourage to contribute to if the         project is fully funded. If no fund is selected, the default is the         project's sector fund.", blank=True, related_name='overflow', to='peacecorps.Account'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='published',
+            field=models.BooleanField(default=False, help_text='If selected,         the project will be visible to the public.'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='slug',
+            field=models.SlugField(max_length=120, help_text='Automatically generated, use for the                             project URL.'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='tagline',
+            field=models.CharField(null=True, max_length=240, help_text='A short title, used as a subheading on the         home page.', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='title',
+            field=models.CharField(max_length=120, help_text='The title of the project.'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='volunteerhomestate',
+            field=localflavor.us.models.USPostalCodeField(verbose_name='Volunteer Home State', null=True, max_length=2, help_text='The home state of the Volunteer.', blank=True, choices=[('AL', 'Alabama'), ('AK', 'Alaska'), ('AS', 'American Samoa'), ('AZ', 'Arizona'), ('AR', 'Arkansas'), ('AA', 'Armed Forces Americas'), ('AE', 'Armed Forces Europe'), ('AP', 'Armed Forces Pacific'), ('CA', 'California'), ('CO', 'Colorado'), ('CT', 'Connecticut'), ('DE', 'Delaware'), ('DC', 'District of Columbia'), ('FM', 'Federated States of Micronesia'), ('FL', 'Florida'), ('GA', 'Georgia'), ('GU', 'Guam'), ('HI', 'Hawaii'), ('ID', 'Idaho'), ('IL', 'Illinois'), ('IN', 'Indiana'), ('IA', 'Iowa'), ('KS', 'Kansas'), ('KY', 'Kentucky'), ('LA', 'Louisiana'), ('ME', 'Maine'), ('MH', 'Marshall Islands'), ('MD', 'Maryland'), ('MA', 'Massachusetts'), ('MI', 'Michigan'), ('MN', 'Minnesota'), ('MS', 'Mississippi'), ('MO', 'Missouri'), ('MT', 'Montana'), ('NE', 'Nebraska'), ('NV', 'Nevada'), ('NH', 'New Hampshire'), ('NJ', 'New Jersey'), ('NM', 'New Mexico'), ('NY', 'New York'), ('NC', 'North Carolina'), ('ND', 'North Dakota'), ('MP', 'Northern Mariana Islands'), ('OH', 'Ohio'), ('OK', 'Oklahoma'), ('OR', 'Oregon'), ('PW', 'Palau'), ('PA', 'Pennsylvania'), ('PR', 'Puerto Rico'), ('RI', 'Rhode Island'), ('SC', 'South Carolina'), ('SD', 'South Dakota'), ('TN', 'Tennessee'), ('TX', 'Texas'), ('UT', 'Utah'), ('VT', 'Vermont'), ('VI', 'Virgin Islands'), ('VA', 'Virginia'), ('WA', 'Washington'), ('WV', 'West Virginia'), ('WI', 'Wisconsin'), ('WY', 'Wyoming')]),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='volunteername',
+            field=models.CharField(verbose_name='Volunteer Name', max_length=120, help_text='The name of the PCV requesting funds for the project.'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='volunteerpicture',
+            field=models.ForeignKey(verbose_name='Volunteer Picture', null=True, help_text='A picture of the PCV requesting funds for the project.         Should be 175px by 175px.', blank=True, related_name='volunteer', to='peacecorps.Media'),
+        ),
+    ]

--- a/peacecorps/peacecorps/migrations/0010_auto_20150316_1535.py
+++ b/peacecorps/peacecorps/migrations/0010_auto_20150316_1535.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import peacecorps.util.svg
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('peacecorps', '0009_auto_20150313_1852'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='featuredcampaign',
+            name='image',
+            field=models.ForeignKey(help_text='Image shown on the landing page. 1100px         wide by 589px tall.', to='peacecorps.Media'),
+        ),
+        migrations.AlterField(
+            model_name='issue',
+            name='icon',
+            field=models.FileField(validators=[peacecorps.util.svg.full_validation], help_text='An SVG file used to represent the issue. The background         should be transparent.', upload_to='icons'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='abstract',
+            field=models.TextField(null=True, blank=True, help_text='A shorter description, used for quick views of the         project.', max_length=256),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='campaigns',
+            field=models.ManyToManyField(to='peacecorps.Campaign', null=True, blank=True, help_text='The issues this project is associated with.'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='country',
+            field=models.ForeignKey(related_name='projects', help_text='The country the project is located in. The project will         appear in the Project Sorter under this country.', to='peacecorps.Country'),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='overflow',
+            field=models.ForeignKey(related_name='overflow', help_text="The fund donors will be encourage to contribute to if the         project is fully funded. By default, this is the project's         sector fund.", null=True, blank=True, to='peacecorps.Account'),
+        ),
+    ]

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -119,18 +119,25 @@ class Account(models.Model):
         (PROJECT, 'Project'),
     )
 
-    name = models.CharField(max_length=NAME_LENGTH, unique=True)
-    code = models.CharField(max_length=25, primary_key=True)
+    name = models.CharField(max_length=NAME_LENGTH, unique=True,
+        help_text="The name of the project or fund.")
+    code = models.CharField(max_length=25, primary_key=True,
+        help_text="The accounting code for the project or fund.")
     current = models.IntegerField(
         default=0,
-        help_text="Amount from donations (excluding real-time), in cents")
+        help_text="Amount from donations (excluding real-time contributions), \
+        in cents.")
     goal = models.IntegerField(
         blank=True, null=True,
-        help_text="Donations goal (excluding community contribution)")
+        help_text="For PCPP projects, the funding goal, excluding community \
+        contribution.")
     # @todo does it make sense for this to default zero?
-    community_contribution = models.IntegerField(blank=True, null=True)
+    community_contribution = models.IntegerField(blank=True, null=True, 
+        help_text="For PCPP projects, the amount of community contributions, \
+        in cents.")
     category = models.CharField(
-        max_length=10, choices=CATEGORY_CHOICES)
+        max_length=10, choices=CATEGORY_CHOICES, help_text="The type of \
+        account.")
 
     objects = AccountManager()
 
@@ -218,34 +225,50 @@ class Campaign(models.Model, AbstractHTMLMixin):
         (OTHER, 'Other'),
     )
 
-    name = models.CharField(max_length=NAME_LENGTH)
-    account = models.ForeignKey('Account', unique=True)
+    name = models.CharField(max_length=NAME_LENGTH, 
+        help_text="The title for the associated campaign.")
+    account = models.ForeignKey('Account', unique=True, 
+        help_text="The accounting code for this campaign.")
     campaigntype = models.CharField(
-        max_length=10, choices=CAMPAIGNTYPE_CHOICES)
+        max_length=10, choices=CAMPAIGNTYPE_CHOICES,
+        help_text="The type of campaign.",
+        verbose_name="Campaign Type")
     icon = models.ForeignKey(
         'Media', null=True, blank=True, related_name="campaign-icons",
-        help_text="A small photo shown on listing pages")
+        help_text="Used for Memorial Funds. Typically a picture of the \
+        volunteer. Should be 120px tall and 120px wide, with the focus of the \
+        photo centered.",
+        verbose_name="Memorial Fund Volunteer Image")
     featured_image = models.ForeignKey(
         'Media', null=True, blank=True, related_name="campaign-headers",
-        help_text="A large landscape image for use in banners, headers, etc")
+        help_text="A large landscape image for use at the top of the campaign \
+        page. Should be 1100px wide and 454px tall.")
     tagline = models.CharField(
         max_length=140,
-        help_text="a short phrase for banners (140 characters)",
+        help_text="If the campaign is featured on the home page, this text is \
+        used as the description of the campaign.",
         blank=True, null=True)
     call = models.CharField(
-        max_length=50, help_text="call to action for buttons (50 characters)",
+        max_length=50, help_text="If the campaign is featured on the home \
+        page, this text is used in the button as a Call to Action.",
         blank=True, null=True)
     slug = models.SlugField(
-        help_text="Auto-generated. Used for the campaign page url.",
+        help_text="Auto-generated. Used for the campaign page URL.",
         max_length=NAME_LENGTH, unique=True)
-    description = BraveSirTrevorField(help_text="the full description.")
+    description = BraveSirTrevorField(help_text="A rich text description. \
+        of the campaign.")
     featuredprojects = models.ManyToManyField('Project', blank=True, null=True)
     country = models.ForeignKey(
-        'Country', related_name="campaign", blank=True, null=True, unique=True)
-    abstract = models.TextField(blank=True, null=True, max_length=256)
+        'Country', related_name="campaign", blank=True, null=True, unique=True,
+        help_text="If the campaign is related to a specific country, the ID \
+        of that country.")
+    abstract = models.TextField(blank=True, null=True, max_length=256,
+        help_text="A shorter description, used for quick views of the \
+        campaign.")
 
     # Unlike projects, funds start published
-    published = models.BooleanField(default=True)
+    published = models.BooleanField(default=True, help_text="If published, \
+        the project will be publicly visible on the site.")
 
     objects = models.Manager()
     published_objects = PublishedManager()

--- a/peacecorps/peacecorps/models.py
+++ b/peacecorps/peacecorps/models.py
@@ -318,7 +318,7 @@ class FeaturedCampaign(models.Model):
                                  help_text="The campaign to feature.")
     image = models.ForeignKey(
         'Media', help_text='Image shown on the landing page. 1100px \
-        wide by 475px tall.')
+        wide by 589px tall.')
 
     class Meta:
         verbose_name = 'Featured Campaign'
@@ -426,10 +426,11 @@ class Project(models.Model, AbstractHTMLMixin):
     description = BraveSirTrevorField(help_text="A rich text description \
         of the project..")
     country = models.ForeignKey('Country', related_name="projects",
-        help_text="The country the project is located in.")
+        help_text="The country the project is located in. The project will \
+        appear in the Project Sorter under this country.")
     campaigns = models.ManyToManyField(
         'Campaign',
-        help_text="The campaigns this project is related to.",
+        help_text="The issues this project is associated with.",
         blank=True, null=True)
     featured_image = models.ForeignKey(
         'Media', null=True, blank=True,
@@ -442,8 +443,8 @@ class Project(models.Model, AbstractHTMLMixin):
     overflow = models.ForeignKey(
         'Account', blank=True, null=True, related_name='overflow',
         help_text="The fund donors will be encourage to contribute to if the \
-        project is fully funded. If no fund is selected, the default is the \
-        project's sector fund.")
+        project is fully funded. By default, this is the project's \
+        sector fund.")
     volunteername = models.CharField(max_length=NAME_LENGTH,
         verbose_name="Volunteer Name",
         help_text="The name of the PCV requesting funds for the project.")
@@ -457,7 +458,7 @@ class Project(models.Model, AbstractHTMLMixin):
         help_text="The home state of the Volunteer.")
     abstract = models.TextField(blank=True, null=True,
         help_text="A shorter description, used for quick views of the \
-        project.")
+        project.", max_length=256)
 
     # Unlike funds, projects start unpublished
     published = models.BooleanField(default=False, help_text="If selected, \
@@ -516,7 +517,8 @@ class Issue(models.Model):
     name = models.CharField(max_length=NAME_LENGTH,
         help_text="The name of the issue.")
     icon = models.FileField(    # No need for any of the 'Media' fields
-        help_text="An SVG file used to represent the issue.",
+        help_text="An SVG file used to represent the issue. The background \
+        should be transparent.",
         upload_to='icons', validators=[svg.full_validation])
     icon_background = models.FileField(
         help_text="The background image to use behind the SVG icon. Should be \


### PR DESCRIPTION
This PR does a few things to help with documentation and help text:
- Adds `apps.py` to the `peacecorps` app, providing the app with a proper plaintext name
- Adds verbose names to the `FAQ` model
- Adds or revises help text across the board to be more descriptive. 
