### PR TITLE
/s/git/https

### DIFF
--- a/provision/dev/bootstrap.sh
+++ b/provision/dev/bootstrap.sh
@@ -21,6 +21,7 @@ sudo npm install -g grunt-cli
 
 
 sudo su vagrant <<'EOF'
+export USE_HTTPS=True
 curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
 echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,7 @@ boto
 python-logstash
 # Version 0.5.0 breaks backwards compatibility
 django-admin-sortable2==0.3.3
-# The pypi version hasn't caught up yet. When possible, switch to django-elasticache>=0.0.3
--e git+https://github.com/gusdan/django-elasticache.git#egg=django-elasticache
+django-elasticache>=0.0.3
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
 -e git+https+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages
 # Fixes an upstream bug. See https://github.com/mapmyfitness/django-gzipping-cache/pull/1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,8 @@ python-logstash
 # Version 0.5.0 breaks backwards compatibility
 django-admin-sortable2==0.3.3
 # The pypi version hasn't caught up yet. When possible, switch to django-elasticache>=0.0.3
--e git://github.com/gusdan/django-elasticache.git#egg=django-elasticache
+-e git+https://github.com/gusdan/django-elasticache.git#egg=django-elasticache
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
--e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages
+-e git+https+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages
 # Fixes an upstream bug. See https://github.com/mapmyfitness/django-gzipping-cache/pull/1
--e git+https://github.com/18f/django-gzipping-cache.git#egg=django-gzipping-cache
+-e git+https+https://github.com/18f/django-gzipping-cache.git#egg=django-gzipping-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ django-admin-sortable2==0.3.3
 # The pypi version hasn't caught up yet. When possible, switch to django-elasticache>=0.0.3
 -e git+https://github.com/gusdan/django-elasticache.git#egg=django-elasticache
 # @see http://code.larlet.fr/django-storages/issue/155/python-3-support
--e git+https+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages
+-e git+https://github.com/coagulant/django-storages-py3.git@py3#egg=django-storages
 # Fixes an upstream bug. See https://github.com/mapmyfitness/django-gzipping-cache/pull/1
--e git+https+https://github.com/18f/django-gzipping-cache.git#egg=django-gzipping-cache
+-e git+https://github.com/18f/django-gzipping-cache.git#egg=django-gzipping-cache


### PR DESCRIPTION
This PR forces the use of `https` over `git` protocols to prevent issues when trying to provision and setup behind picky corporate firewalls.
