### PR TITLE
PayGov Service Alert

### DIFF
--- a/peacecorps/peacecorps/templates/donations/checkout_form.jinja
+++ b/peacecorps/peacecorps/templates/donations/checkout_form.jinja
@@ -1,5 +1,7 @@
 {% extends "donations/checkout_base.jinja" %}
 
+{% include "donations/includes/paygov-alert.jinja" %}
+
 {% block form_content %}
     <form action="" method="post" class="js-form section__content"
           data-ajax-url="{{ajax_url}}">

--- a/peacecorps/peacecorps/templates/donations/includes/paygov-alert.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/paygov-alert.jinja
@@ -1,0 +1,13 @@
+{% block top_most_banner %}
+<section class="u-align_c t--white"
+         style="background-color: #333; padding: 5%; ">
+  <h2>Notice</h2>
+  <p class="t-body--md t--white">
+    Thank you for your interest in supporting the amazing work of our Peace Corps Volunteers! <br/>
+    Please note, our trusted payment processor pay.gov will be upgrading their systems on <br/>
+    <strong>Saturday, May 9, from 6:00pm – 12:00am EDT</strong> <br/>
+    and during that time we will be unable to process your payment. 
+  </p>
+</section>
+{% endblock %}
+


### PR DESCRIPTION
Pay.gov service alert for May 9th, 2015 since Pay.gov will be down on Saturday, May 9, 6pm - midnight.

We would like this branch to be deployed to Production COB Friday or Friday night and then taken down (deploy regular master release) on Monday morning. Thanks.
