### PR TITLE
Paygov banner alert for June 13

### DIFF
--- a/peacecorps/peacecorps/templates/donations/checkout_form.jinja
+++ b/peacecorps/peacecorps/templates/donations/checkout_form.jinja
@@ -1,5 +1,7 @@
 {% extends "donations/checkout_base.jinja" %}
 
+{% include "donations/includes/paygov-alert.jinja" %}
+
 {% block form_content %}
     <form action="" method="post" class="js-form section__content"
           data-ajax-url="{{ajax_url}}">

--- a/peacecorps/peacecorps/templates/donations/includes/paygov-alert.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/paygov-alert.jinja
@@ -5,7 +5,7 @@
   <p class="t-body--md t--white">
     Thank you for your interest in supporting the amazing work of our Peace Corps Volunteers! <br/>
     Please note, our trusted payment processor pay.gov will be upgrading their systems on <br/>
-    <strong>Saturday, May 9, from 6:00pm – 12:00am EDT</strong> <br/>
+    <strong>Saturday, June 13, from 6:00pm – Midnight EDT</strong> <br/>
     and during that time we will be unable to process your payment. 
   </p>
 </section>

--- a/peacecorps/peacecorps/templates/donations/includes/paygov-alert.jinja
+++ b/peacecorps/peacecorps/templates/donations/includes/paygov-alert.jinja
@@ -1,0 +1,13 @@
+{% block top_most_banner %}
+<section class="u-align_c t--white"
+         style="background-color: #333; padding: 5%; ">
+  <h2>Notice</h2>
+  <p class="t-body--md t--white">
+    Thank you for your interest in supporting the amazing work of our Peace Corps Volunteers! <br/>
+    Please note, our trusted payment processor pay.gov will be upgrading their systems on <br/>
+    <strong>Saturday, May 9, from 6:00pm – 12:00am EDT</strong> <br/>
+    and during that time we will be unable to process your payment. 
+  </p>
+</section>
+{% endblock %}
+


### PR DESCRIPTION
Hi @cmc333333 , we will need to put up another Pay.gov alert on Saturday June 13th and taken off Sunday morning. If it's more convenient for you to deploy it Friday night and take it off Monday morning, that's fine as well. This can be deployed the same way the previous pay.gov alert was deployed (as a tagged release of the paygov-banner-alert branch). Let me know what works for you. Thanks!
