### PR TITLE
Remove donor name param from success page

### DIFF
--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -143,18 +143,16 @@ def generate_custom_fields(data):
     return custom
 
 
-def redirect_urls(account, donor_name):
+def redirect_urls(account):
     """Success and return URLs are derived from the account. Also the
     donor's first name to the url"""
     if account.category == Account.PROJECT:
         project = account.project_set.first()
-        return (reverse('project success', kwargs={'slug': project.slug})
-                + '?' + urlencode({'donor_name': donor_name}),
+        return (reverse('project success', kwargs={'slug': project.slug}),
                 reverse('project failure', kwargs={'slug': project.slug}))
     else:
         campaign = account.campaign_set.first()
-        return (reverse('campaign success', kwargs={'slug': campaign.slug})
-                + '?' + urlencode({'donor_name': donor_name}),
+        return (reverse('campaign success', kwargs={'slug': campaign.slug}),
                 reverse('campaign failure', kwargs={'slug': campaign.slug}))
 
 
@@ -172,7 +170,7 @@ def convert_to_paygov(data, account, callback_base):
     data['payer_name'] = data.get('payer_name',
                                   data.get('organization_name', ''))
     data['success_url'], data['failure_url'] = (
-        callback_base + url for url in redirect_urls(account, donor_first))
+        callback_base + url for url in redirect_urls(account))
     data.update(generate_custom_fields(data))
     xml = generate_collection_request(data)
     return DonorInfo(agency_tracking_id=tracking_id, account=account,

--- a/peacecorps/peacecorps/payxml.py
+++ b/peacecorps/peacecorps/payxml.py
@@ -164,8 +164,6 @@ def convert_to_paygov(data, account, callback_base):
     data['agency_tracking_id'] = tracking_id
     data['agency_memo'] = generate_agency_memo(data)
     data['form_id'] = settings.PAY_GOV_FORM_ID
-    # quick method of finding the donor's first name
-    donor_first = data.get('payer_name', '').split(' ')[0]
     # payer_name could be the individual or organization field
     data['payer_name'] = data.get('payer_name',
                                   data.get('organization_name', ''))

--- a/peacecorps/peacecorps/tests/test_xmlgen.py
+++ b/peacecorps/peacecorps/tests/test_xmlgen.py
@@ -181,19 +181,17 @@ class PayXMLGenerationTests(TestCase):
         campaign = Campaign.objects.create(
             account=account, slug='cccccc')
 
-        succ, fail = payxml.redirect_urls(account, "Bob/Mary")
+        succ, fail = payxml.redirect_urls(account)
         self.assertTrue('success' in succ)
         self.assertTrue('project' in succ)
-        self.assertTrue('Bob%2FMary' in succ)
         self.assertTrue('failure' in fail)
         self.assertTrue('project' in fail)
         proj.delete()
 
         account.category = Account.COUNTRY
-        succ, fail = payxml.redirect_urls(account, "Bob+Mary")
+        succ, fail = payxml.redirect_urls(account)
         self.assertTrue('success' in succ)
         self.assertTrue('fund' in succ)
-        self.assertTrue('Bob%2BMary' in succ)
         self.assertTrue('failure' in fail)
         self.assertTrue('fund' in fail)
 


### PR DESCRIPTION
Hi @cmc333333 ,
When you get the chance, could you merge and deploy this to the dev site. The change involves removing the donor name from the redirect urls after the pay.gov transaction. This was a slight concern due to our GA tracking donor first names in the url. The django tests passed (after a bit modifications to the test since the redirect_urls method's donor_name param was remove), but we'd also like to test the full donation process on dev before this is deployed to production.

Thanks,
Saad
